### PR TITLE
Temporary workaround for ESI cache killer: append query string

### DIFF
--- a/src/html.htl
+++ b/src/html.htl
@@ -24,10 +24,10 @@
   </head>
 <body>
   <!--  header -->
-  <header><esi:include src="/header.plain.html" onerror="continue"/></header>
+  <header><esi:include src="/header.plain.html${request.queryString @ context='unsafe'}" onerror="continue" /></header>
   <!--  content -->
   ${content.document.body.innerHTML @ context = 'unsafe'}
   <!--  footer -->
-  <footer><esi:include src="/footer.plain.html"  onerror="continue"/></footer>
+  <footer><esi:include src="/footer.plain.html${request.queryString @ context='unsafe'}" onerror="continue"/></footer>
 </body>
 </html>

--- a/src/html.pre.js
+++ b/src/html.pre.js
@@ -20,6 +20,17 @@ function pre(context) {
   const { document } = context.content;
   const $ = jquery(document.defaultView);
 
+  /* workaround until cache purge is properly setup */
+  let queryString = '';
+  let separator = '?';
+  Object.keys(context.request.params).forEach((key) => {
+    queryString += `${separator}${key}=${context.request.params[key]}`;
+    separator = '&';
+  });
+  // eslint-disable-next-line no-param-reassign
+  context.request.queryString = queryString;
+  /* end of workaround */
+
   /* workaround until sections in document are fixed via PR on pipeline */
   let currentCollection = [];
   const sections = [];


### PR DESCRIPTION
PR for #29 