### PR TITLE
empty <header> and <footer> if not there

### DIFF
--- a/htdocs/style.css
+++ b/htdocs/style.css
@@ -169,7 +169,7 @@ table {
     border-spacing: 0;    
 }
 
-header .plain {
+header {
     position: fixed;
     background-color: black;
     color: white;
@@ -236,18 +236,17 @@ header .section:nth-child(2) ul {
     list-style: none;
 }
 
-header,
 footer {
-    font-size: 0;
-}
-
-footer .plain {
     background-color: #cccccc;
     padding: 20px 0px;
     font-size: 0.5em;
     color: #888888;
     text-align: center;
     display: block;
+}
+
+header:empty, footer:empty {
+    display: none;
 }
 
 input {

--- a/src/plain_html.htl
+++ b/src/plain_html.htl
@@ -1,1 +1,1 @@
-<div class="plain">${content.document.body.innerHTML @ context = 'unsafe'}</div>
+${content.document.body.innerHTML @ context = 'unsafe'}


### PR DESCRIPTION
there was a new `div.plain` inserted somewhere along the way, which made the `:empty` pseudo-class not work anymore. it seems that a `font-size: 0` work around was put in place to visually hide the header and footer, which comes with a range of side-effects when the menu needs to be visible.

this PR should get us back to the original intent.