### PR TITLE
adding enclosing main tag

### DIFF
--- a/src/html.htl
+++ b/src/html.htl
@@ -7,8 +7,8 @@
 <body>
   <!--  header -->
   <header><esi:include src="/header.plain.html" onerror="continue"/></header>
-  <!--  content -->
-  ${content.document.body.innerHTML @ context = 'unsafe'}
+  <!--  main content -->
+  <main>${content.document.body.innerHTML @ context = 'unsafe'}</main>
   <!--  footer -->
   <footer><esi:include src="/footer.plain.html"  onerror="continue"/></footer>
 </body>


### PR DESCRIPTION
as described in #41 i think we should symmetrically add `<main>` into the default helix-pages output
