### PR TITLE
workaround for lack of ESI silent continue

### DIFF
--- a/htdocs/head.html
+++ b/htdocs/head.html
@@ -4,7 +4,16 @@
 <script src="https://d6uhzlpot4xwe.cloudfront.net/runtime/1.21/themes/wiper-fonts.gz.js"></script>
 <script src="/scrani.js"></script>
 <script>
+  function removeHeaderAndFooter () {
+    // workaound until the ESI is fixed
+    const header=document.querySelector("header");
+    const footer=document.querySelector("footer");
+    if (header.innerHTML == "/header.plain.html") header.innerHTML = "";
+    if (footer.innerHTML == "/footer.plain.html") footer.innerHTML = "";
+  }
+
   window.onload = function() {
+    removeHeaderAndFooter();
     scrani.onload();
   }
 

--- a/htdocs/head.html
+++ b/htdocs/head.html
@@ -6,7 +6,7 @@
 <script>
   function removeHeaderAndFooter () {
     // workaound until the ESI is fixed
-    const header=document.querySelector("header");
+    const header = document.querySelector("header");
     const footer=document.querySelector("footer");
     if (header.innerHTML == "/header.plain.html") header.innerHTML = "";
     if (footer.innerHTML == "/footer.plain.html") footer.innerHTML = "";

--- a/htdocs/head.html
+++ b/htdocs/head.html
@@ -7,7 +7,7 @@
   function removeHeaderAndFooter () {
     // workaound until the ESI is fixed
     const header = document.querySelector("header");
-    const footer=document.querySelector("footer");
+    const footer = document.querySelector("footer");
     if (header.innerHTML == "/header.plain.html") header.innerHTML = "";
     if (footer.innerHTML == "/footer.plain.html") footer.innerHTML = "";
   }


### PR DESCRIPTION
i think this workaround has the least forward compatibility issues as it exposes the DOM how we expect it to be in the end after the ESI issue has been fixed.

it has a somewhat undesirable flash effect, but i think this should keep reminding to fix #10 