### PR TITLE
feat(cache): disable the cache by default

### DIFF
--- a/src/html.pre.js
+++ b/src/html.pre.js
@@ -21,6 +21,13 @@ function pre(context) {
   const { document } = context.content;
   const $ = jquery(document.defaultView);
 
+  /* cache killer */
+  context.response = context.response || {}
+  context.response.headers = context.response.headers || {};
+  context.response.headers['Cache-Control'] = 'no-cache';
+  context.response.headers['Surrogate-Control'] = 'max-age=0';
+  /* end of cache killer */
+
   /* workaround until sections in document are fixed via PR on pipeline */
   let currentCollection = [];
   const sections = [];

--- a/src/html.pre.js
+++ b/src/html.pre.js
@@ -9,6 +9,7 @@
  * OF ANY KIND, either express or implied. See the License for the specific language
  * governing permissions and limitations under the License.
  */
+/* eslint-disable no-param-reassign */
 const jquery = require('jquery');
 const { preFetch } = require('./utils.js');
 
@@ -22,7 +23,7 @@ function pre(context) {
   const $ = jquery(document.defaultView);
 
   /* cache killer */
-  context.response = context.response || {}
+  context.response = context.response || {};
   context.response.headers = context.response.headers || {};
   context.response.headers['Cache-Control'] = 'no-cache';
   context.response.headers['Surrogate-Control'] = 'max-age=0';

--- a/src/plain_html.pre.js
+++ b/src/plain_html.pre.js
@@ -9,6 +9,7 @@
  * OF ANY KIND, either express or implied. See the License for the specific language
  * governing permissions and limitations under the License.
  */
+/* eslint-disable no-param-reassign */
 const jquery = require('jquery');
 
 /**
@@ -21,7 +22,7 @@ function pre(context) {
   const $ = jquery(document.defaultView);
 
   /* cache killer */
-  context.response = context.response || {}
+  context.response = context.response || {};
   context.response.headers = context.response.headers || {};
   context.response.headers['Cache-Control'] = 'no-cache';
   context.response.headers['Surrogate-Control'] = 'max-age=0';

--- a/src/plain_html.pre.js
+++ b/src/plain_html.pre.js
@@ -20,6 +20,13 @@ function pre(context) {
   const { document } = context.content;
   const $ = jquery(document.defaultView);
 
+  /* cache killer */
+  context.response = context.response || {}
+  context.response.headers = context.response.headers || {};
+  context.response.headers['Cache-Control'] = 'no-cache';
+  context.response.headers['Surrogate-Control'] = 'max-age=0';
+  /* end of cache killer */
+
   /* workaround until sections in document are fixed via PR on pipeline */
   let currentCollection = [];
   const sections = [];


### PR DESCRIPTION
PR for #17 

This PR adds the required headers so that the `no-cache` required headers are returned by the 2 actions (plain.html and html) and go through our VCL.
Consequence: no cache is happening on Fastly and a change in an md file will be immediately visible on page reload.
This is only true for the project actions, no for the static one. Different solution is needed here.

Note that our VCL should be cleaned up to simplify the required code. See https://github.com/adobe/helix-publish/issues/137

cc @davidnuescheler @tripodsan @trieloff 