### PR TITLE
disabled eslint rule to reassign param

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -32,6 +32,9 @@ module.exports = {
     // allow dangling underscores for 'fields'
     'no-underscore-dangle': ['error', {'allowAfterThis': true}],
 
+    // allow reassigning param
+    "no-param-reassign": [2, { "props": false }],
+
     // enforce license header
     'header/header': [2, 'block', ['',
       { pattern: ' * Copyright \\d{4} Adobe\\. All rights reserved\\.', template: ' * Copyright 2019 Adobe. All rights reserved.'},


### PR DESCRIPTION
it is necessary for pipeline to reassign `context` values as part of product workflow