### PR TITLE
fix(build): use helix-cli@4.x

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -86,7 +86,7 @@ jobs:
 
       - run:
           name: Installing Helix CLI
-          command: npm install @adobe/helix-cli --save=false
+          command: npm install @adobe/helix-cli@"=4" --save=false
 
       - run:
           name: Build Templates


### PR DESCRIPTION
Fix CLI version to 4.x in order to avoid introducing breaking changes