### PR TITLE
chore(build): follow package naming convention

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "helix-pages",
+  "name": "@adobe/helix-pages",
   "version": "1.10.1",
   "private": true,
   "description": "Helix Pages is the Helix project behind [https://*.project-helix.page/](https://www.project-helix.page/)",


### PR DESCRIPTION
`helix-pages` should follow the same package naming convention as the other Helix services.