### PR TITLE
fix(sitemap): missing helix-query.yaml shouldn't report 500

### DIFF
--- a/cgi-bin/sitemap.js
+++ b/cgi-bin/sitemap.js
@@ -84,12 +84,12 @@ async function run(params) {
   ]);
 
   if (queryYAML.status !== 200) {
-    log.error(`unable to fetch helix-query.yaml: ${queryYAML.status}`);
+    log.info(`unable to fetch helix-query.yaml: ${queryYAML.status}`);
     return {
-      statusCode: 500,
-      body: 'No index definition found.',
+      statusCode: 200,
+      body: '',
       headers: {
-        'Content-Type': 'text/plain',
+        'Content-Type': 'application/xml',
       },
     };
   }

--- a/cgi-bin/sitemap.js
+++ b/cgi-bin/sitemap.js
@@ -77,14 +77,30 @@ async function run(params) {
   const downloader = new Downloader({}, action, {
     forceHttp1: ALGOLIA_APP_ID === 'foo', // use http1 for tests
   });
+  let files;
 
-  const [queryYAML, fstabYAML] = await Promise.all([
-    downloader.fetchGithub({ ...coords, path: '/helix-query.yaml' }),
-    downloader.fetchGithub({ ...coords, path: '/fstab.yaml' }),
-  ]);
+  try {
+    files = await Promise.all([
+      downloader.fetchGithub({ ...coords, path: '/helix-query.yaml' }),
+      downloader.fetchGithub({ ...coords, path: '/fstab.yaml' }),
+    ]);
+  } catch (e) {
+    log.error(e.message);
+    return {
+      statusCode: 500,
+      body: e.message,
+      headers: {
+        'Content-Type': 'text/plain',
+      },
+    };
+  } finally {
+    downloader.destroy();
+  }
 
+  const [queryYAML, fstabYAML] = files;
   if (queryYAML.status !== 200) {
-    log.info(`unable to fetch helix-query.yaml: ${queryYAML.status}`);
+    const logout = (queryYAML.status === 404 ? log.info : log.error).bind(log);
+    logout(`unable to fetch helix-query.yaml: ${queryYAML.status}`);
     return {
       statusCode: 200,
       body: '',

--- a/test/unit/sitemap.test.js
+++ b/test/unit/sitemap.test.js
@@ -75,9 +75,10 @@ describe('Sitemap Tests', () => {
         .get('/me/repo/master/fstab.yaml')
         .reply(404, 'Not found');
     });
-    it('missing index returns 500', async () => {
+    it('missing index returns 200 and empty body', async () => {
       const response = await proxyaction().main(createParams());
-      assert.equal(response.statusCode, 500);
+      assert.equal(response.statusCode, 200);
+      assert.equal(response.body, '');
     });
   });
 

--- a/test/unit/sitemap.test.js
+++ b/test/unit/sitemap.test.js
@@ -82,6 +82,21 @@ describe('Sitemap Tests', () => {
     });
   });
 
+  describe('Other failure reading index', () => {
+    before(() => {
+      nock('https://raw.githubusercontent.com')
+        .get('/me/repo/master/helix-query.yaml')
+        .reply(500, 'Something went wrong');
+      nock('https://raw.githubusercontent.com')
+        .get('/me/repo/master/fstab.yaml')
+        .reply(404, 'Not found');
+    });
+    it('failing to read index should report error', async () => {
+      const response = await proxyaction().main(createParams());
+      assert.equal(response.statusCode, 500);
+    });
+  });
+
   describe('Index available, no fstab', () => {
     beforeEach(() => {
       nock('https://raw.githubusercontent.com')


### PR DESCRIPTION
When an index definition file `helix-query.yaml` isn't present, the sitemap generation should silently fail, and not report 10 errors per ESincluded page.