### PR TITLE
fix(seo): workaround: use relative URL for canonical link

### DIFF
--- a/src/html.pre.js
+++ b/src/html.pre.js
@@ -10,7 +10,7 @@
  * governing permissions and limitations under the License.
  */
 const jquery = require('jquery');
-const { getOriginalHost } = require('../src/utils');
+// const { getOriginalHost } = require('../src/utils');
 
 /**
  * The 'pre' function that is executed before the HTML is rendered

--- a/src/html.pre.js
+++ b/src/html.pre.js
@@ -80,7 +80,9 @@ function pre(context) {
     })
     .toArray();
   meta.description = `${desc.slice(0, 25).join(' ')}${desc.length > 25 ? ' ...' : ''}`;
-  meta.url = `https://${getOriginalHost(request.headers)}${request.url}`;
+  // switched from absolute to relative URL as a workaround for https://github.com/adobe/helix-pages/issues/284
+  // meta.url = `https://${getOriginalHost(request.headers)}${request.url}`;
+  meta.url = request.url;
   meta.imageUrl = content.image;
 }
 

--- a/test/unit/html.pre.test.js
+++ b/test/unit/html.pre.test.js
@@ -140,7 +140,8 @@ describe('Testing pre.js', () => {
     assert.ok(context.content.meta.description.endsWith('...'));
   });
 
-  it('Meta url uses x-hlx-pages-host if available', () => {
+  // skipped due to workaround for https://github.com/adobe/helix-pages/issues/284
+  it.skip('Meta url uses x-hlx-pages-host if available', () => {
     const dom = new JSDOM('<html><head><title>Foo</title></head><body></body></html');
     const context = {
       content: {
@@ -155,7 +156,8 @@ describe('Testing pre.js', () => {
     assert.equal(context.content.meta.url, `https://${context.request.headers['x-hlx-pages-host']}${context.request.url}`);
   });
 
-  it('Meta url uses x-cdn-url header if no x-hlx-pages-host available', () => {
+  // skipped due to workaround for https://github.com/adobe/helix-pages/issues/284
+  it.skip('Meta url uses x-forwarded-host header if no x-hlx-pages-host available', () => {
     const req = {
       ...request,
       headers: {
@@ -176,7 +178,8 @@ describe('Testing pre.js', () => {
     assert.equal(context.content.meta.url, req.headers['x-cdn-url']);
   });
 
-  it('Meta url uses host header if no x-cdn-url available', () => {
+  // switched from absolute to relative URL as a workaround for https://github.com/adobe/helix-pages/issues/284
+  it('Meta url uses relative URL if no host header available', () => {
     const req = {
       ...request,
       headers: {
@@ -195,7 +198,7 @@ describe('Testing pre.js', () => {
     };
     pre(context);
 
-    assert.equal(context.content.meta.url, `https://${req.headers.host}${req.url}`);
+    assert.equal(context.content.meta.url, req.url);
   });
 
   it('Meta imageUrl uses content.image', () => {


### PR DESCRIPTION
Fix #284 (temporary workaround)