### PR TITLE
fix(seo): use relative url only in canonical link

### DIFF
--- a/src/html.htl
+++ b/src/html.htl
@@ -3,7 +3,7 @@
 <head>
   <title>${content.title}</title>
   <meta data-sly-test.hash=${content.data.sourceHash} name="x-source-hash" content="${hash}"/>
-  <link data-sly-test="${content.meta.url}" rel="canonical" href="${content.meta.url}"/>
+  <link data-sly-test="${content.meta.canonicalUrl}" rel="canonical" href="${content.meta.canonicalUrl}"/>
   <meta data-sly-test="${content.meta.description}" name="description" content="${content.meta.description}"/>
   <meta data-sly-test="${content.title}" property="og:title" content="${content.title}"/>
   <meta data-sly-test="${content.meta.description}" property="og:description" content="${content.meta.description}"/>

--- a/src/html.pre.js
+++ b/src/html.pre.js
@@ -10,7 +10,7 @@
  * governing permissions and limitations under the License.
  */
 const jquery = require('jquery');
-// const { getOriginalHost } = require('../src/utils');
+const { getOriginalHost } = require('../src/utils');
 
 /**
  * The 'pre' function that is executed before the HTML is rendered
@@ -80,9 +80,9 @@ function pre(context) {
     })
     .toArray();
   meta.description = `${desc.slice(0, 25).join(' ')}${desc.length > 25 ? ' ...' : ''}`;
-  // switched from absolute to relative URL as a workaround for https://github.com/adobe/helix-pages/issues/284
-  // meta.url = `https://${getOriginalHost(request.headers)}${request.url}`;
-  meta.url = request.url;
+  meta.url = `https://${getOriginalHost(request.headers)}${request.url}`;
+  // switched from absolute to relative URL for the canonical link, see https://github.com/adobe/helix-pages/issues/284
+  meta.canonicalUrl = request.url;
   meta.imageUrl = content.image;
 }
 

--- a/test/unit/html.pre.test.js
+++ b/test/unit/html.pre.test.js
@@ -140,8 +140,7 @@ describe('Testing pre.js', () => {
     assert.ok(context.content.meta.description.endsWith('...'));
   });
 
-  // skipped due to workaround for https://github.com/adobe/helix-pages/issues/284
-  it.skip('Meta url uses x-hlx-pages-host if available', () => {
+  it('Meta url uses x-hlx-pages-host if available', () => {
     const dom = new JSDOM('<html><head><title>Foo</title></head><body></body></html');
     const context = {
       content: {
@@ -156,8 +155,7 @@ describe('Testing pre.js', () => {
     assert.equal(context.content.meta.url, `https://${context.request.headers['x-hlx-pages-host']}${context.request.url}`);
   });
 
-  // skipped due to workaround for https://github.com/adobe/helix-pages/issues/284
-  it.skip('Meta url uses x-forwarded-host header if no x-hlx-pages-host available', () => {
+  it('Meta url uses x-cdn-url header if no x-hlx-pages-host available', () => {
     const req = {
       ...request,
       headers: {
@@ -179,7 +177,7 @@ describe('Testing pre.js', () => {
   });
 
   // switched from absolute to relative URL as a workaround for https://github.com/adobe/helix-pages/issues/284
-  it('Meta url uses relative URL if no host header available', () => {
+  it('Meta canonical url uses relative URL', () => {
     const req = {
       ...request,
       headers: {
@@ -198,7 +196,7 @@ describe('Testing pre.js', () => {
     };
     pre(context);
 
-    assert.equal(context.content.meta.url, req.url);
+    assert.equal(context.content.meta.canonicalUrl, req.url);
   });
 
   it('Meta imageUrl uses content.image', () => {


### PR DESCRIPTION
See https://github.com/adobe/helix-pages/issues/284#issuecomment-635301308