### PR TITLE
fix(seo): use hlx-forwarded-host header and switch canonical url back to absolute

### DIFF
--- a/src/html.htl
+++ b/src/html.htl
@@ -3,7 +3,7 @@
 <head>
   <title>${content.title}</title>
   <meta data-sly-test.hash=${content.data.sourceHash} name="x-source-hash" content="${hash}"/>
-  <link data-sly-test="${content.meta.canonicalUrl}" rel="canonical" href="${content.meta.canonicalUrl}"/>
+  <link data-sly-test="${content.meta.url}" rel="canonical" href="${content.meta.url}"/>
   <meta data-sly-test="${content.meta.description}" name="description" content="${content.meta.description}"/>
   <meta data-sly-test="${content.title}" property="og:title" content="${content.title}"/>
   <meta data-sly-test="${content.meta.description}" property="og:description" content="${content.meta.description}"/>

--- a/src/html.pre.js
+++ b/src/html.pre.js
@@ -81,8 +81,6 @@ function pre(context) {
     .toArray();
   meta.description = `${desc.slice(0, 25).join(' ')}${desc.length > 25 ? ' ...' : ''}`;
   meta.url = getAbsoluteUrl(request.headers, request.url);
-  // switched from absolute to relative URL for the canonical link, see https://github.com/adobe/helix-pages/issues/284
-  meta.canonicalUrl = request.url;
   meta.imageUrl = getAbsoluteUrl(request.headers, content.image);
 }
 

--- a/src/utils.js
+++ b/src/utils.js
@@ -16,11 +16,8 @@
  * @returns {string} The original host
  */
 function getOriginalHost(headers) {
-  if (headers['x-hlx-pages-host']) {
-    return headers['x-hlx-pages-host'];
-  }
-  if (headers['x-cdn-url']) {
-    return new URL(headers['x-cdn-url']).hostname;
+  if (headers['hlx-forwarded-host']) {
+    return headers['hlx-forwarded-host'];
   }
   return headers.host;
 }

--- a/test/unit/sitemap.test.js
+++ b/test/unit/sitemap.test.js
@@ -45,7 +45,7 @@ const createParams = () => ({
   ALGOLIA_API_KEY: 'bar',
   __ow_headers: {
     'x-forwarded-proto': 'https',
-    'x-cdn-url': 'https://myhost.com/sitemap.xml',
+    'hlx-forwarded-host': 'myhost.com',
   },
 });
 


### PR DESCRIPTION
Fix #284

Note: we are retiring support for `x-hlx-pages-host` in the process.