### PR TITLE
feat(markup): add helix markup properties to the html root node

### DIFF
--- a/src/html.htl
+++ b/src/html.htl
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html data-sly-attribute="${content.document.body.attributesMap}">
 <head>
   <title>${content.title}</title>
   <meta data-sly-test.hash=${content.data.sourceHash} name="x-source-hash" content="${hash}"/>
@@ -26,7 +26,7 @@
   <!--  header -->
   <header><esi:include src="/header.plain.html" onerror="continue"/></header>
   <!--  main content -->
-  <main>${content.document.body}</main>
+  <main data-sly-list="${content.document.body.children}">${item}</main>
   <!--  footer -->
   <footer><esi:include src="/footer.plain.html"  onerror="continue"/></footer>
 </body>

--- a/src/html.pre.js
+++ b/src/html.pre.js
@@ -22,6 +22,20 @@ function pre(context) {
   const { document } = content;
   const $ = jquery(document.defaultView);
 
+  // if there is only a single child, merge its properties on the body node
+  // and attach its children directly to the body
+  document.body.attributesMap = {};
+  if (document.body.children.length === 1) {
+    const rootElement = document.body.children[0];
+    // Merge the root element properties onto the body element
+    [...rootElement.attributes].forEach((attr) => {
+      document.body.attributesMap[attr.name] = attr.value;
+    });
+    // Re-attach root element children directly to the body
+    [...rootElement.children].forEach((child) => document.body.appendChild(child));
+    document.body.removeChild(rootElement);
+  }
+
   const $sections = $(document.body).children('div');
 
   // first section has a starting image: add title class and wrap all subsequent items inside a div


### PR DESCRIPTION
When there is a single child on the body element, merge its properties
on the html element and directly inline its children on the body tag.

fix adobe/theblog#241