### PR TITLE
Cache in production

### DIFF
--- a/test/smoke/homepage.smoke.js
+++ b/test/smoke/homepage.smoke.js
@@ -85,7 +85,7 @@ describe('homepage smoke tests - subdomain extraction and some page content', ()
         .then((response) => {
           expect(response).to.be.html;
           expect(response).to.have.status(200);
-          expect(response).to.have.header('cache-control', /^private/);
+          expect(response).to.have.header('cache-control', /private/);
         }).catch((e) => {
           throw e;
         });

--- a/test/smoke/homepage.smoke.js
+++ b/test/smoke/homepage.smoke.js
@@ -85,6 +85,7 @@ describe('homepage smoke tests - subdomain extraction and some page content', ()
         .then((response) => {
           expect(response).to.be.html;
           expect(response).to.have.status(200);
+          expect(response).to.have.header('cache-control', /^private/);
         }).catch((e) => {
           throw e;
         });

--- a/vcl/extensions.vcl
+++ b/vcl/extensions.vcl
@@ -15,7 +15,7 @@ sub hlx_type_pipeline_before {
     # If you have an outer CDN, then it looks like "www.mydomain.com, repo--user.hlx.page"
     # The filter below tests if you have an outer CDN and turns off the development mode
     # caching (i.e. re-enables caching in helix-dispatch)
-    if(regsuball(regsuball(req.http.x-forwarded-host, "[^,]*(\.hlx\.page|\.project\-helix\.page|\.fastlydemo\.net)", ""), "[, ]", "") == "") {
+    if(regsuball(regsuball(req.http.x-forwarded-host, "[^,]*(\.hlx(-[0-9]+)?\.page|\.project\-helix\.page|\.fastlydemo\.net)", ""), "[, ]", "") == "") {
         set req.http.X-Dispatch-NoCache = "true";
     }
 }

--- a/vcl/extensions.vcl
+++ b/vcl/extensions.vcl
@@ -13,8 +13,8 @@
 sub hlx_type_pipeline_before {
     # A non-production XFH header looks like: "repo--user.hlx.page"
     # If you have an outer CDN, then it looks like "www.mydomain.com, repo--user.hlx.page"
-    # The filter below tests if you have an outer CDN and turns off the development mode
-    # caching (i.e. re-enables caching in helix-dispatch)
+    # The filter below tests if you have no outer CDN and turns on the development mode
+    # caching (i.e. disables caching in helix-dispatch)
     if(regsuball(regsuball(req.http.x-forwarded-host, "[^,]*(\.hlx(-[0-9]+)?\.page|\.project\-helix\.page|\.fastlydemo\.net)", ""), "[, ]", "") == "") {
         set req.http.X-Dispatch-NoCache = "true";
     }

--- a/vcl/extensions.vcl
+++ b/vcl/extensions.vcl
@@ -11,7 +11,13 @@
 #
 
 sub hlx_type_pipeline_before {
-    set req.http.X-Dispatch-NoCache = "true";
+    # A non-production XFN header looks like: "repo--user.hlx.page"
+    # If you have an outer CDN, then it looks like "www.mydomain.com, repo--user.hlx.page"
+    # The filter below tests if you have an outer CDN and turns off the development mode
+    # caching (i.e. re-enables caching in helix-dispatch)
+    if(regsuball(regsuball(req.http.x-forwarded-host, "[^,]*(\.hlx\.page|\.project\-helix\.page|\.fastlydemo\.net)", ""), "[, ]", "") == "") {
+        set req.http.X-Dispatch-NoCache = "true";
+    }
 }
 sub hlx_type_pipeline_after {}
 

--- a/vcl/extensions.vcl
+++ b/vcl/extensions.vcl
@@ -11,7 +11,7 @@
 #
 
 sub hlx_type_pipeline_before {
-    # A non-production XFN header looks like: "repo--user.hlx.page"
+    # A non-production XFH header looks like: "repo--user.hlx.page"
     # If you have an outer CDN, then it looks like "www.mydomain.com, repo--user.hlx.page"
     # The filter below tests if you have an outer CDN and turns off the development mode
     # caching (i.e. re-enables caching in helix-dispatch)


### PR DESCRIPTION
This PR splits `helix-pages` caching behavior in two modes:

1. developer-mode, where all responses from `helix-dispatch` will remain uncached as before
2. production mode, that caches exactly like a regular Helix website

Developer mode is ideal for making changes to your site quickly and will be enabled when accessing any subdomain of `hlx.page` or `project-helix.page`.

Production mode is meant for running in production and will be enabled when accessing a site using an outer CDN. This means that caching rules like #402 no longer have to be replicated in the outer CDN, but that all customers running Helix Pages with an outer CDN will benefit from centrally managed caching rules.

As a plus, it also means fewer activations for us.