### PR TITLE
fix(feed): wrap feed entries with CDATA

### DIFF
--- a/cgi-bin/feed.js
+++ b/cgi-bin/feed.js
@@ -38,7 +38,9 @@ function loc(host, hit) {
     <id>${host}/${hit.id}</id>
     <title>${hit.title}</title>
     <updated>${hit.updated.toISOString()}</updated>
-    <content><esi:include src="/${hit.id.replace(/\.html$/, '.embed.html')}"></esi:include></content>
+    <content><![CDATA[
+      <esi:include src="/${hit.id.replace(/\.html$/, '.embed.html')}"></esi:include>
+   ]]></content>
   </entry>
 `;
 }

--- a/test/unit/feed/feed-fstab.txt
+++ b/test/unit/feed/feed-fstab.txt
@@ -3,33 +3,43 @@
     <id>https://blog.adobe.com/en/publish/2020/08/03/adobe-portfolio-is-now-free-for-1-year-for-2020-college-grads.html</id>
     <title>Adobe Portfolio is Now Free for 1 Year for 2020 College Grads</title>
     <updated>2020-08-03T00:00:00.000Z</updated>
-    <content><esi:include src="/en/publish/2020/08/03/adobe-portfolio-is-now-free-for-1-year-for-2020-college-grads.embed.html"></esi:include></content>
+    <content><![CDATA[
+      <esi:include src="/en/publish/2020/08/03/adobe-portfolio-is-now-free-for-1-year-for-2020-college-grads.embed.html"></esi:include>
+   ]]></content>
   </entry>
 
   <entry>
     <id>https://blog.adobe.com/en/publish/2020/08/03/cai-achieves-milestone-white-paper-sets-the-standard-for-content-attribution.html</id>
     <title>CAI Achieves Milestone: White Paper Sets the Standard for Content Attribution</title>
     <updated>2020-08-03T00:00:00.000Z</updated>
-    <content><esi:include src="/en/publish/2020/08/03/cai-achieves-milestone-white-paper-sets-the-standard-for-content-attribution.embed.html"></esi:include></content>
+    <content><![CDATA[
+      <esi:include src="/en/publish/2020/08/03/cai-achieves-milestone-white-paper-sets-the-standard-for-content-attribution.embed.html"></esi:include>
+   ]]></content>
   </entry>
 
   <entry>
     <id>https://blog.adobe.com/en/publish/2020/08/03/midnight-gospel-on-netflix.html</id>
     <title>Midnight Gospel on Netflix Animated by Titmouse</title>
     <updated>2020-08-03T00:00:00.000Z</updated>
-    <content><esi:include src="/en/publish/2020/08/03/midnight-gospel-on-netflix.embed.html"></esi:include></content>
+    <content><![CDATA[
+      <esi:include src="/en/publish/2020/08/03/midnight-gospel-on-netflix.embed.html"></esi:include>
+   ]]></content>
   </entry>
 
   <entry>
     <id>https://blog.adobe.com/en/publish/2020/08/03/tapping-into-the-power-of-ai-to-drive-better-b2b-event-marketing.html</id>
     <title>Tapping into the Power of AI to Drive Better B2B Event Marketing</title>
     <updated>2020-08-03T00:00:00.000Z</updated>
-    <content><esi:include src="/en/publish/2020/08/03/tapping-into-the-power-of-ai-to-drive-better-b2b-event-marketing.embed.html"></esi:include></content>
+    <content><![CDATA[
+      <esi:include src="/en/publish/2020/08/03/tapping-into-the-power-of-ai-to-drive-better-b2b-event-marketing.embed.html"></esi:include>
+   ]]></content>
   </entry>
 
   <entry>
     <id>https://blog.adobe.com/en/publish/2020/08/03/the-american-red-cross-life-saving-work-using-digital-experiences.html</id>
     <title>The American Red Cross: Life-saving work using digital experiences</title>
     <updated>2020-08-03T00:00:00.000Z</updated>
-    <content><esi:include src="/en/publish/2020/08/03/the-american-red-cross-life-saving-work-using-digital-experiences.embed.html"></esi:include></content>
+    <content><![CDATA[
+      <esi:include src="/en/publish/2020/08/03/the-american-red-cross-life-saving-work-using-digital-experiences.embed.html"></esi:include>
+   ]]></content>
   </entry>


### PR DESCRIPTION
Some authors have the audacity not to write well-formed XHTML, which can break the feed. This fix wraps each entry in a CDATA block.