### PR TITLE
September Breaking Changes (test)

### DIFF
--- a/.github/workflows/wip.yaml
+++ b/.github/workflows/wip.yaml
@@ -1,0 +1,12 @@
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, labeled, unlabeled]
+
+jobs:
+  block_label:
+    runs-on: ubuntu-latest
+    name: Check for 'breaking' label
+    steps:
+      - uses: adobe-rnd/github-label-wip-action@master
+        with:
+          label: breaking

--- a/BREAKING.md
+++ b/BREAKING.md
@@ -12,6 +12,8 @@ in order to give a preview of upcoming breaking changes.
 Pipeline that enables the new version-lock feature
 
 - https://github.com/adobe/helix-pipeline/pull/840
+- `https://github.com/adobe/helix-pipeline.git#helix-lock-support`
+
 
 ### helix-dispatch
 

--- a/BREAKING.md
+++ b/BREAKING.md
@@ -1,0 +1,40 @@
+# Breaking Changes
+
+_DRAFT_
+
+This branch is a test to see how specific versions of helix services can be selected
+in order to give a preview of upcoming breaking changes.
+
+## Selected Services
+
+### helix-pipeline
+
+Pipeline that enables the new version-lock feature
+
+- https://github.com/adobe/helix-pipeline/pull/840
+
+### helix-dispatch
+
+Dispatch that enables the new version-lock feature
+
+- https://github.com/adobe/helix-dispatch/pull/338
+- `/helix/helix-services/dispatch@ci1939`
+
+### helix-contentproxy
+
+Contentproxy that enables the new version-lock feature
+
+- https://github.com/adobe/helix-content-proxy/pull/155
+- `/helix/helix-services/content-proxy@ci830`
+
+### helix-gdocs2md
+
+Google docs converter that has a slight different table handling.
+
+- https://github.com/adobe/helix-gdocs2md/pull/330
+- `/helix/helix-services/gdocs2md@ci1485`
+
+# TODO:
+
+- add simple mechanism to tag some PRs in order to get a stable CI version.
+- add a tool to collect/update tagged services

--- a/BREAKING.md
+++ b/BREAKING.md
@@ -5,6 +5,14 @@ _DRAFT_
 This branch is a test to see how specific versions of helix services can be selected
 in order to give a preview of upcoming breaking changes.
 
+## How to publish
+
+**DON'T PUBLISH TO THE REAL PAGES Service** (yet)
+
+```
+hlx publish --custom-vcl='vcl/extensions.vcl' --dispatchVersion=ci1939
+```
+
 ## Selected Services
 
 ### helix-pipeline

--- a/BREAKING.md
+++ b/BREAKING.md
@@ -13,6 +13,14 @@ in order to give a preview of upcoming breaking changes.
 hlx publish --custom-vcl='vcl/extensions.vcl' --dispatchVersion=ci1939
 ```
 
+## Example Request
+
+```
+curl -sD - 'https://master--pages--adobe.99productrules.com/premiere/en/yts-livestream?a=5' \
+  -H 'x-ow-version-lock: content-proxy=content-proxy@ci830&gdocs2md=gdocs2md@ci1485' \
+  -H 'x-strain: breaking-september'
+```
+
 ## Selected Services
 
 ### helix-pipeline

--- a/helix-config.yaml
+++ b/helix-config.yaml
@@ -14,3 +14,9 @@ strains:
     content: https://github.com/adobe/helix-pages.git#master
     static: https://github.com/adobe/helix-pages.git/htdocs#master
     package: helix-pages/b316d674a1d0b5be59750f20aa8ab0d6f8f08048
+  # strain for breaking changes
+  - name: breaking-september
+    code: https://github.com/adobe/helix-pages.git#breaking-september
+    content: https://github.com/adobe/helix-pages.git#breaking-september
+    static: https://github.com/adobe/helix-pages.git/htdocs#breaking-september
+    # version-lock: .....

--- a/helix-config.yaml
+++ b/helix-config.yaml
@@ -19,5 +19,5 @@ strains:
     code: https://github.com/adobe/helix-pages.git#breaking-september-test
     content: https://github.com/adobe/helix-pages.git#breaking-september-test
     static: https://github.com/adobe/helix-pages.git/htdocs#breaking-september-test
-    package: tripod/a1db359d94a85033b7ef8a8fea49e27ec06a584c
+    package: tripod/github-com--adobe--helix-pages--breaking-september-test-dirty
     # version-lock: .....

--- a/helix-config.yaml
+++ b/helix-config.yaml
@@ -16,8 +16,7 @@ strains:
     package: helix-pages/b316d674a1d0b5be59750f20aa8ab0d6f8f08048
   # strain for breaking changes
   - name: breaking-september
-    code: https://github.com/adobe/helix-pages.git#breaking-september-test
-    content: https://github.com/adobe/helix-pages.git#breaking-september-test
-    static: https://github.com/adobe/helix-pages.git/htdocs#breaking-september-test
-    package: tripod/github-com--adobe--helix-pages--breaking-september-test-dirty
+    code: https://github.com/adobe/helix-pages.git#breaking-september
+    content: https://github.com/adobe/helix-pages.git#breaking-september
+    static: https://github.com/adobe/helix-pages.git/htdocs#breaking-september
     # version-lock: .....

--- a/helix-config.yaml
+++ b/helix-config.yaml
@@ -16,7 +16,7 @@ strains:
     package: helix-pages/b316d674a1d0b5be59750f20aa8ab0d6f8f08048
   # strain for breaking changes
   - name: breaking-september
-    code: https://github.com/adobe/helix-pages.git#breaking-september
-    content: https://github.com/adobe/helix-pages.git#breaking-september
-    static: https://github.com/adobe/helix-pages.git/htdocs#breaking-september
+    code: https://github.com/adobe/helix-pages.git#breaking-september-test
+    content: https://github.com/adobe/helix-pages.git#breaking-september-test
+    static: https://github.com/adobe/helix-pages.git/htdocs#breaking-september-test
     # version-lock: .....

--- a/helix-config.yaml
+++ b/helix-config.yaml
@@ -19,4 +19,5 @@ strains:
     code: https://github.com/adobe/helix-pages.git#breaking-september-test
     content: https://github.com/adobe/helix-pages.git#breaking-september-test
     static: https://github.com/adobe/helix-pages.git/htdocs#breaking-september-test
+    package: tripod/a1db359d94a85033b7ef8a8fea49e27ec06a584c
     # version-lock: .....

--- a/helix-config.yaml
+++ b/helix-config.yaml
@@ -19,5 +19,4 @@ strains:
     code: https://github.com/adobe/helix-pages.git#breaking-september-test
     content: https://github.com/adobe/helix-pages.git#breaking-september-test
     static: https://github.com/adobe/helix-pages.git/htdocs#breaking-september-test
-    package: tripod/8859415a707d98a7bf5872c74a61fc4513269850
     # version-lock: .....

--- a/helix-config.yaml
+++ b/helix-config.yaml
@@ -19,4 +19,5 @@ strains:
     code: https://github.com/adobe/helix-pages.git#breaking-september-test
     content: https://github.com/adobe/helix-pages.git#breaking-september-test
     static: https://github.com/adobe/helix-pages.git/htdocs#breaking-september-test
+    package: tripod/8859415a707d98a7bf5872c74a61fc4513269850
     # version-lock: .....

--- a/helix-config.yaml
+++ b/helix-config.yaml
@@ -19,4 +19,5 @@ strains:
     code: https://github.com/adobe/helix-pages.git#breaking-september
     content: https://github.com/adobe/helix-pages.git#breaking-september
     static: https://github.com/adobe/helix-pages.git/htdocs#breaking-september
+    package: tripod/f5c2344487e801fe0f72b474ec38e107fe8189c6
     # version-lock: .....

--- a/package-lock.json
+++ b/package-lock.json
@@ -57,9 +57,8 @@
       }
     },
     "@adobe/helix-pipeline": {
-      "version": "10.5.1",
-      "resolved": "https://registry.npmjs.org/@adobe/helix-pipeline/-/helix-pipeline-10.5.1.tgz",
-      "integrity": "sha512-c5r9QyvbZVSH8rAwFdVY9Xj2VgNobFkMCw+gCu8ZYQlTN3CuzDVuTVK/Ga8aFFEtT+BKtAqjyT/GWk7u8PlLVA==",
+      "version": "git+https://github.com/adobe/helix-pipeline.git#de48bf8baac7b96176e15fc5e9c14da000496d6c",
+      "from": "git+https://github.com/adobe/helix-pipeline.git#helix-lock-support",
       "requires": {
         "@adobe/helix-epsagon": "1.5.1",
         "@adobe/helix-fetch": "1.9.1",
@@ -67,7 +66,7 @@
         "@adobe/helix-shared": "7.11.0",
         "@adobe/helix-status": "8.1.3",
         "@adobe/openwhisk-action-logger": "2.2.0",
-        "@adobe/openwhisk-action-utils": "4.2.3",
+        "@adobe/openwhisk-action-utils": "4.3.0",
         "@emmetio/expand-abbreviation": "^0.7.3",
         "ajv": "^6.10.2",
         "callsites": "^3.1.0",
@@ -106,19 +105,6 @@
         "web-namespaces": "^1.1.3",
         "xml2js": "^0.4.19",
         "xmlbuilder": "^15.0.0"
-      },
-      "dependencies": {
-        "@adobe/openwhisk-action-utils": {
-          "version": "4.2.3",
-          "resolved": "https://registry.npmjs.org/@adobe/openwhisk-action-utils/-/openwhisk-action-utils-4.2.3.tgz",
-          "integrity": "sha512-8cklPxw4yG+MoI5ZWaGV1s5i1Wme1do9rLOOddGO20WrmVSdIvsMxIPi+Y4Jl8h/CA0ATiKOjAf7aRMmuh9mhg==",
-          "requires": {
-            "@adobe/helix-log": "^4.1.0",
-            "bunyan": "1.8.14",
-            "openwhisk": "^3.20.0",
-            "serverless-http": "^2.3.0"
-          }
-        }
       }
     },
     "@adobe/helix-shared": {
@@ -5207,31 +5193,6 @@
       "integrity": "sha1-GVoh1sRuNh0vsSgbo4uR6d9727M=",
       "optional": true
     },
-    "needle": {
-      "version": "2.5.2",
-      "resolved": "https://registry.npmjs.org/needle/-/needle-2.5.2.tgz",
-      "integrity": "sha512-LbRIwS9BfkPvNwNHlsA41Q29kL2L/6VaOJ0qisM5lLWsTV3nP15abO5ITL6L81zqFhzjRKDAYjpcBcwM0AVvLQ==",
-      "requires": {
-        "debug": "^3.2.6",
-        "iconv-lite": "^0.4.4",
-        "sax": "^1.2.4"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "3.2.6",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
-          "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
-          "requires": {
-            "ms": "^2.1.1"
-          }
-        },
-        "ms": {
-          "version": "2.1.2",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
-        }
-      }
-    },
     "neo-async": {
       "version": "2.6.2",
       "resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.2.tgz",
@@ -9058,14 +9019,6 @@
       "dev": true,
       "requires": {
         "mimic-fn": "^2.1.0"
-      }
-    },
-    "openwhisk": {
-      "version": "3.21.2",
-      "resolved": "https://registry.npmjs.org/openwhisk/-/openwhisk-3.21.2.tgz",
-      "integrity": "sha512-Fxx1fupwZaKxbzpN/pCd0PLItRAjS9PXJCnm+JFPY7592koQlYTQo3t7DpBVYTiqIUx9Z1kKdpla3JyLaZSXIA==",
-      "requires": {
-        "needle": "^2.4.0"
       }
     },
     "optionator": {

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   "homepage": "https://github.com/adobe/helix-pages#readme",
   "dependencies": {
     "@adobe/helix-fetch": "1.9.1",
-    "@adobe/helix-pipeline": "10.5.1",
+    "@adobe/helix-pipeline": "https://github.com/adobe/helix-pipeline.git#helix-lock-support",
     "@adobe/helix-shared": "7.11.0",
     "@adobe/openwhisk-action-logger": "2.2.0",
     "@adobe/openwhisk-action-utils": "4.3.0",


### PR DESCRIPTION
# Breaking Changes

_DRAFT_

This branch is a test to see how specific versions of helix services can be selected
in order to give a preview of upcoming breaking changes.

## Selected Services

### helix-pipeline

Pipeline that enables the new version-lock feature

- https://github.com/adobe/helix-pipeline/pull/840

### helix-dispatch

Dispatch that enables the new version-lock feature

- https://github.com/adobe/helix-dispatch/pull/338
- `/helix/helix-services/dispatch@ci1939`

### helix-contentproxy

Contentproxy that enables the new version-lock feature

- https://github.com/adobe/helix-content-proxy/pull/155
- `/helix/helix-services/content-proxy@ci830`

### helix-gdocs2md

Google docs converter that has a slight different table handling.

- https://github.com/adobe/helix-gdocs2md/pull/330
- `/helix/helix-services/gdocs2md@ci1485`

# TODO:

- add simple mechanism to tag some PRs in order to get a stable CI version.
- add a tool to collect/update tagged services
