### PR TITLE
fix(html): guard against spaces in class names

### DIFF
--- a/src/html.pre.js
+++ b/src/html.pre.js
@@ -34,7 +34,7 @@ function pre(context) {
   if ($sections.length === 0) {
     const div = document.createElement('div');
     if (context.content.meta && context.content.meta.class) {
-      context.content.meta.class.split(',').forEach((c) => {
+      context.content.meta.class.split(/[ ,]/).forEach((c) => {
         div.classList.add(c.trim());
       });
     }
@@ -59,6 +59,8 @@ function pre(context) {
   meta.description = `${desc.slice(0, 25).join(' ')}${desc.length > 25 ? ' ...' : ''}`;
   meta.url = getAbsoluteUrl(request.headers, request.url);
   meta.imageUrl = getAbsoluteUrl(request.headers, content.image || '/default-meta-image.png');
+
+  console.log(document);
 }
 
 module.exports.pre = pre;

--- a/src/html.pre.js
+++ b/src/html.pre.js
@@ -34,9 +34,12 @@ function pre(context) {
   if ($sections.length === 0) {
     const div = document.createElement('div');
     if (context.content.meta && context.content.meta.class) {
-      context.content.meta.class.split(/[ ,]/).forEach((c) => {
-        div.classList.add(c.trim());
-      });
+      context.content.meta.class.split(/[ ,]/)
+        .map((c) => c.trim())
+        .filter((c) => !!c)
+        .forEach((c) => {
+          div.classList.add(c);
+        });
     }
     wrapContent(div, document.body);
   }
@@ -59,8 +62,6 @@ function pre(context) {
   meta.description = `${desc.slice(0, 25).join(' ')}${desc.length > 25 ? ' ...' : ''}`;
   meta.url = getAbsoluteUrl(request.headers, request.url);
   meta.imageUrl = getAbsoluteUrl(request.headers, content.image || '/default-meta-image.png');
-
-  console.log(document);
 }
 
 module.exports.pre = pre;

--- a/test/unit/html.pre.test.js
+++ b/test/unit/html.pre.test.js
@@ -106,6 +106,24 @@ describe('Testing pre.js', () => {
     assert.ok(div.classList.contains('customcssclass2'));
   });
 
+  it('Div is wrapped with multiple class names even when space separated', () => {
+    const dom = new JSDOM('<html><head><title>Foo</title></head><body><h1>Title</h1></body></html>');
+    const context = {
+      content: {
+        document: dom.window.document,
+        meta: {
+          class: 'customcssclass customcssclass2',
+        },
+      },
+      request,
+    };
+    pre(context);
+
+    const div = dom.window.document.querySelector('div');
+    assert.ok(div.classList.contains('customcssclass'));
+    assert.ok(div.classList.contains('customcssclass2'));
+  });
+
   it('Section divs are left alone', () => {
     const dom = new JSDOM('<html><head><title>Foo</title></head><body><div class="customcssclass"><h1>Title</h1></div></body></html>');
     const context = {


### PR DESCRIPTION
HTML class names cannot contain spaces and JSDOM bails when asked to create a classname with a space. By splitting the class list from metadata at a comma, but not a space, we invite errors when class names are space separated

fixes #482