### PR TITLE
ci(smoke): use the circle ci workflow id to calculate test domain

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -90,7 +90,7 @@ jobs:
           # sed -e "s/................//" – drop a couple of digits, so that we don't exceed expr's max int limit
           # expr $(…) % 7 + 1             – calculate the modulo
           command: |
-              modulo=expr $(echo $CIRCLE_WORKFLOW_ID | sed -e "s/[a-f-]//g" | sed -e "s/................//") % 7 + 1
+              modulo=$(expr $(echo $CIRCLE_WORKFLOW_ID | sed -e "s/[a-f-]//g" | sed -e "s/................//") % 7 + 1)
               name="TEST_DOMAIN_$modulo"
               TEST_DOMAIN=${!name}
               name="TEST_SERVICE_$modulo"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -83,8 +83,14 @@ jobs:
           command: npx hlx deploy --wsk-action-memory 512 --add default --default ALGOLIA_API_KEY $ALGOLIA_API_KEY ALGOLIA_APP_ID $ALGOLIA_APP_ID AZURE_SEARCH_API_KEY $AZURE_SEARCH_API_KEY AZURE_SEARCH_SERVICE_NAME $AZURE_SEARCH_SERVICE_NAME CORALOGIX_API_KEY $CORALOGIX_API_KEY CORALOGIX_LOG_LEVEL $CORALOGIX_LOG_LEVEL EPSAGON_TOKEN $EPSAGON_TOKEN | cat
       - run:
           name: Compute TEST_DOMAIN and TEST_SERVICE
+          
+          # How to calculate the test domain
+          # echo $CIRCLE_WORKFLOW_ID      – use the workflow id because it's stable and available through the API to the triggering job
+          # sed -e "s/[a-f-]//g"          – keep only the decimal digits
+          # sed -e "s/................//" – drop a couple of digits, so that we don't exceed expr's max int limit
+          # expr $(…) % 7 + 1             – calculate the modulo
           command: |
-              modulo=$(expr $CIRCLE_BUILD_NUM % 7 + 1)
+              modulo=expr $(echo $CIRCLE_WORKFLOW_ID | sed -e "s/[a-f-]//g" | sed -e "s/................//") % 7 + 1
               name="TEST_DOMAIN_$modulo"
               TEST_DOMAIN=${!name}
               name="TEST_SERVICE_$modulo"


### PR DESCRIPTION
the workflow id is stable and available through the API to the triggering job (e.g. helix-publish) so that branch-specific tests can be run there. That way I can not just do regression tests, but test new helix-publish features without the catch-22 of having to have them either in helix-pages master or helix-publish master.