### PR TITLE
chore(test): changes in static files are not tested

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -82,6 +82,14 @@ jobs:
           name: Deploy to Adobe I/O Runtime
           command: npx hlx deploy --wsk-action-memory 512 --add default --default ALGOLIA_API_KEY $ALGOLIA_API_KEY ALGOLIA_APP_ID $ALGOLIA_APP_ID AZURE_SEARCH_API_KEY $AZURE_SEARCH_API_KEY AZURE_SEARCH_SERVICE_NAME $AZURE_SEARCH_SERVICE_NAME CORALOGIX_API_KEY $CORALOGIX_API_KEY CORALOGIX_LOG_LEVEL $CORALOGIX_LOG_LEVEL EPSAGON_TOKEN $EPSAGON_TOKEN | cat
       - run:
+          name: Setup branch in helix-config.yaml
+          command: |
+            echo "Prior to modifications"
+            cat helix-config.yaml
+            sed -i -e 's/#master/#$CIRCLE_BRANCH/' helix-config.yaml
+            echo "Post modifications"
+            cat helix-config.yaml
+      - run:
           name: Compute TEST_DOMAIN and TEST_SERVICE
           
           # How to calculate the test domain

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -83,14 +83,10 @@ jobs:
           command: npx hlx deploy --wsk-action-memory 512 --add default --default ALGOLIA_API_KEY $ALGOLIA_API_KEY ALGOLIA_APP_ID $ALGOLIA_APP_ID AZURE_SEARCH_API_KEY $AZURE_SEARCH_API_KEY AZURE_SEARCH_SERVICE_NAME $AZURE_SEARCH_SERVICE_NAME CORALOGIX_API_KEY $CORALOGIX_API_KEY CORALOGIX_LOG_LEVEL $CORALOGIX_LOG_LEVEL EPSAGON_TOKEN $EPSAGON_TOKEN | cat
       - run:
           name: Setup branch in helix-config.yaml
+
+          # replace "master" by the branch name in helix-config
           command: |
-            echo "Prior to modifications"
-            cat helix-config.yaml
             sed -i -e "s/#master/#$CIRCLE_BRANCH/" helix-config.yaml 
-            echo
-            echo
-            echo "Post modifications"
-            cat helix-config.yaml
       - run:
           name: Compute TEST_DOMAIN and TEST_SERVICE
           

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -79,9 +79,6 @@ jobs:
           name: Build Templates
           command: npx hlx build
       - run:
-          name: Deploy to Adobe I/O Runtime
-          command: npx hlx deploy --wsk-action-memory 512 --add default --default ALGOLIA_API_KEY $ALGOLIA_API_KEY ALGOLIA_APP_ID $ALGOLIA_APP_ID AZURE_SEARCH_API_KEY $AZURE_SEARCH_API_KEY AZURE_SEARCH_SERVICE_NAME $AZURE_SEARCH_SERVICE_NAME CORALOGIX_API_KEY $CORALOGIX_API_KEY CORALOGIX_LOG_LEVEL $CORALOGIX_LOG_LEVEL EPSAGON_TOKEN $EPSAGON_TOKEN | cat
-      - run:
           name: Setup branch in helix-config.yaml
           command: |
             echo "Prior to modifications"
@@ -89,6 +86,9 @@ jobs:
             sed -i -e "s/#master/#$CIRCLE_BRANCH/" helix-config.yaml 
             echo "Post modifications"
             cat helix-config.yaml
+      - run:
+          name: Deploy to Adobe I/O Runtime
+          command: npx hlx deploy --dirty --wsk-action-memory 512 --add default --default ALGOLIA_API_KEY $ALGOLIA_API_KEY ALGOLIA_APP_ID $ALGOLIA_APP_ID AZURE_SEARCH_API_KEY $AZURE_SEARCH_API_KEY AZURE_SEARCH_SERVICE_NAME $AZURE_SEARCH_SERVICE_NAME CORALOGIX_API_KEY $CORALOGIX_API_KEY CORALOGIX_LOG_LEVEL $CORALOGIX_LOG_LEVEL EPSAGON_TOKEN $EPSAGON_TOKEN | cat
       - run:
           name: Compute TEST_DOMAIN and TEST_SERVICE
           

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -79,16 +79,18 @@ jobs:
           name: Build Templates
           command: npx hlx build
       - run:
+          name: Deploy to Adobe I/O Runtime
+          command: npx hlx deploy --wsk-action-memory 512 --add default --default ALGOLIA_API_KEY $ALGOLIA_API_KEY ALGOLIA_APP_ID $ALGOLIA_APP_ID AZURE_SEARCH_API_KEY $AZURE_SEARCH_API_KEY AZURE_SEARCH_SERVICE_NAME $AZURE_SEARCH_SERVICE_NAME CORALOGIX_API_KEY $CORALOGIX_API_KEY CORALOGIX_LOG_LEVEL $CORALOGIX_LOG_LEVEL EPSAGON_TOKEN $EPSAGON_TOKEN | cat
+      - run:
           name: Setup branch in helix-config.yaml
           command: |
             echo "Prior to modifications"
             cat helix-config.yaml
             sed -i -e "s/#master/#$CIRCLE_BRANCH/" helix-config.yaml 
+            echo
+            echo
             echo "Post modifications"
             cat helix-config.yaml
-      - run:
-          name: Deploy to Adobe I/O Runtime
-          command: npx hlx deploy --dirty --wsk-action-memory 512 --add default --default ALGOLIA_API_KEY $ALGOLIA_API_KEY ALGOLIA_APP_ID $ALGOLIA_APP_ID AZURE_SEARCH_API_KEY $AZURE_SEARCH_API_KEY AZURE_SEARCH_SERVICE_NAME $AZURE_SEARCH_SERVICE_NAME CORALOGIX_API_KEY $CORALOGIX_API_KEY CORALOGIX_LOG_LEVEL $CORALOGIX_LOG_LEVEL EPSAGON_TOKEN $EPSAGON_TOKEN | cat
       - run:
           name: Compute TEST_DOMAIN and TEST_SERVICE
           

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -86,7 +86,7 @@ jobs:
           command: |
             echo "Prior to modifications"
             cat helix-config.yaml
-            sed -i -e 's/#master/#$CIRCLE_BRANCH/' helix-config.yaml
+            sed -i -e "s/#master/#$CIRCLE_BRANCH/" helix-config.yaml 
             echo "Post modifications"
             cat helix-config.yaml
       - run:

--- a/htdocs/head.html
+++ b/htdocs/head.html
@@ -1,1 +1,4 @@
-
+<link rel="stylesheet" href="/styles.css"/>
+<meta name="viewport" content="width=device-width, initial-scale=1"/>
+<link rel="shortcut icon" type="image/x-icon" href="/favicon.ico">
+<script src="/scripts.js"></script>

--- a/htdocs/head.html
+++ b/htdocs/head.html
@@ -1,4 +1,1 @@
-<link rel="stylesheet" href="/styles.css"/>
-<meta name="viewport" content="width=device-width, initial-scale=1"/>
-<link rel="shortcut icon" type="image/x-icon" href="/favicon.ico">
-<script src="/scripts.js"></script>
+

--- a/test/pages/pages.test.js
+++ b/test/pages/pages.test.js
@@ -81,6 +81,14 @@ async function getTestSetup() {
   };
 }
 
+// remove known attributes that may be different
+function filterDOM(document) {
+  const sourceHash = document.querySelector('meta[name="x-source-hash"]');
+  if (sourceHash) {
+    sourceHash.remove();
+  }
+}
+
 describe('document equivalence', async () => {
   try {
     const setup = await getTestSetup();
@@ -89,9 +97,11 @@ describe('document equivalence', async () => {
       const { original: originalURL, test: testURL } = getTestURLs(setup.mostVisitedUrls[idx]);
 
       const orig_dom = new JSDOM(base).window.document;
+      filterDOM(orig_dom);
 
       const test_text = fixDomainInTestContent(setup.testDoms[idx]);
       const test_dom = new JSDOM(test_text).window.document;
+      filterDOM(test_dom);
 
       describe(`Comparing ${originalURL} against ${testURL}`, () => {
         it('testing body node', () => {

--- a/vcl/extensions.vcl
+++ b/vcl/extensions.vcl
@@ -93,5 +93,7 @@ sub hlx_ref_after {
     if (var.ref != "") {
         # override X-Ref
         set req.http.X-Ref= var.ref;
+    } else {
+        set req.http.X-Ref = "master";
     }
 }

--- a/vcl/extensions.vcl
+++ b/vcl/extensions.vcl
@@ -80,6 +80,8 @@ sub hlx_repo_after {
     if (var.r != "") {
         # override X-Repo
         set req.http.X-Repo = var.r;
+        # default branch to master
+        set req.http.X-Ref = "master";
     }
 }
 

--- a/vcl/extensions.vcl
+++ b/vcl/extensions.vcl
@@ -93,7 +93,5 @@ sub hlx_ref_after {
     if (var.ref != "") {
         # override X-Ref
         set req.http.X-Ref= var.ref;
-    } else {
-        set req.http.X-Ref = "master";
     }
 }

--- a/vcl/extensions.vcl
+++ b/vcl/extensions.vcl
@@ -52,6 +52,7 @@ sub hlx_owner_after {
     if (var.o != "") {
         // override X-Owner
         set req.http.X-Owner = var.o;
+        set req.http.X-URL-Override = true;
     }
 }
 
@@ -80,8 +81,6 @@ sub hlx_repo_after {
     if (var.r != "") {
         # override X-Repo
         set req.http.X-Repo = var.r;
-        # default branch to master
-        set req.http.X-Ref = "master";
     }
 }
 
@@ -95,5 +94,11 @@ sub hlx_ref_after {
     if (var.ref != "") {
         # override X-Ref
         set req.http.X-Ref= var.ref;
+    } else {
+        if (req.http.X-URL-Override) {
+            # default branch to master if there is a url override but no branch provided
+            set req.http.X-Ref = "master";
+        }
     }
+    unset req.http.X-URL-Override;
 }


### PR DESCRIPTION
Fix #513

2 majors changes:
- VCL: if `owner` and `repo` is present in the url but no `branch/ref`, default the `ref` to `master`. This was the case before but only because the `ref` defaults to helix-pages `branch`, i.e. `master`.
- Update the branch in `helix-config.yaml` prior to hlx publish so that the VCL code knows which is the current helix-pages `branch` to use and not only for the `code` part (`content` and `static`)

I put the PR in draft just to make sure it does not get merged before MAX.