### PR TITLE
feat(test): add support for version lock in diff tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,6 +17,10 @@ parameters:
     type: string
     default: ""
     description: the helix-publish ci version to use
+  version_lock:
+    type: string
+    default: ""
+    description: the version lock string
 
 orbs:
   puppeteer: threetreeslight/puppeteer@0.1.2
@@ -34,7 +38,7 @@ commands:
           keys:
             - v4-dependencies-{{ arch }}-{{ checksum "package-lock.json" }}
       - run:
-          name: install npm 
+          name: install npm
           command: sudo npm -g install npm
       - run:
           name: Installing Dependencies
@@ -86,10 +90,10 @@ jobs:
 
           # replace "master" by the branch name in helix-config
           command: |
-            sed -i -e "s/#master/#$CIRCLE_BRANCH/" helix-config.yaml 
+            sed -i -e "s/#master/#$CIRCLE_BRANCH/" helix-config.yaml
       - run:
-          name: Compute TEST_DOMAIN and TEST_SERVICE
-          
+          name: Compute TEST_DOMAIN and TEST_SERVICE and TEST_VERSION_LOCK
+
           command: |
               modulo=$(expr << pipeline.number >> % 7 + 1)
               name="TEST_DOMAIN_$modulo"
@@ -100,10 +104,14 @@ jobs:
               # "pass" the variable to the next steps...
               echo "export TEST_DOMAIN=$TEST_DOMAIN" >> env/TEST_DOMAIN
               echo "export TEST_SERVICE=$TEST_SERVICE" >> env/TEST_SERVICE
+              echo "export TEST_VERSION_LOCK=<< pipeline.parameters.version_lock >>" >> env/TEST_VERSION_LOCK
+
               cat env/TEST_DOMAIN >> $BASH_ENV
               cat env/TEST_SERVICE >> $BASH_ENV
+              cat env/TEST_VERSION_LOCK >> $BASH_ENV
               # debug logs
               echo "A TEST_DOMAIN has been computed - hlx-$modulo"
+              echo "Using version lock: << pipeline.parameters.version_lock >>"
       - run:
           name: Publish to Fastly
           command: |
@@ -155,6 +163,7 @@ jobs:
           command: |
             cat env/TEST_DOMAIN >> $BASH_ENV
             cat env/TEST_SERVICE >> $BASH_ENV
+            cat env/TEST_VERSION_LOCK >> $BASH_ENV
 
       - run:
           name: Cloning << parameters.owner >>/<< parameters.repo >>
@@ -210,6 +219,7 @@ jobs:
           command: |
             cat env/TEST_DOMAIN >> $BASH_ENV
             cat env/TEST_SERVICE >> $BASH_ENV
+            cat env/TEST_VERSION_LOCK >> $BASH_ENV
 
       - run:
           name: Run the smoke tests for << parameters.owner >>/<< parameters.repo >>
@@ -293,6 +303,7 @@ jobs:
           command: |
             cat env/TEST_DOMAIN >> $BASH_ENV
             cat env/TEST_SERVICE >> $BASH_ENV
+            cat env/TEST_VERSION_LOCK >> $BASH_ENV
 
       - run:
           name: Run Helix Page Diff tests

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "semantic-release": "semantic-release",
     "test:hlx.pge.smoketest": "mocha test/smoke/*.* -t 5000 --domain $TEST_DOMAIN",
     "test:hlx.pge.generic.smoketester": "mocha test/smoketester/*.* -t 5000 --domain $TEST_DOMAIN --owner $TEST_OWNER --repo $TEST_REPO --branch $TEST_BRANCH --index $TEST_INDEX",
-    "test:pages": "env TEST_DOMAIN=$TEST_DOMAIN mocha --delay --exit test/pages/*.* -t 5000"
+    "test:pages": "env TEST_DOMAIN=$TEST_DOMAIN TEST_VERSION_LOCK=\"$TEST_VERSION_LOCK\" mocha --delay --exit test/pages/*.* -t 5000"
   },
   "repository": {
     "type": "git",

--- a/test/pages/pages.test.js
+++ b/test/pages/pages.test.js
@@ -33,9 +33,7 @@ const testOpts = {
   },
 };
 
-console.log('Using test domain:', testDomain);
 if (testVersionLock) {
-  console.log('Using version lock:', testVersionLock);
   testOpts.headers['x-ow-version-lock'] = testVersionLock;
 }
 

--- a/test/pages/pages.test.js
+++ b/test/pages/pages.test.js
@@ -9,19 +9,63 @@
  * OF ANY KIND, either express or implied. See the License for the specific language
  * governing permissions and limitations under the License.
  */
-/* eslint-disable no-undef */
-/* eslint-disable camelcase */
+/* eslint-disable no-undef,no-console,camelcase */
+const assert = require('assert');
 const { fetch } = require('@adobe/helix-fetch');
 const { JSDOM } = require('jsdom');
 const { dumpDOM, assertEquivalentNode } = require('@adobe/helix-shared').dom;
 
 const testDomain = process.env.TEST_DOMAIN;
+const testVersionLock = process.env.TEST_VERSION_LOCK;
 
-async function getText(data) {
-  if (!data.ok) {
-    throw new Error(`Unable to load ${data.url} (${data.status}): ${await data.text()}`);
+const origOpts = {
+  cache: 'no-cache',
+  headers: {
+    'Cache-Control': 'no-cache',
+  },
+};
+
+const testOpts = {
+  cache: 'no-cache',
+  headers: {
+    'Cache-Control': 'no-cache',
+  },
+};
+
+console.log('Using test domain:', testDomain);
+if (testVersionLock) {
+  console.log('Using version lock:', testVersionLock);
+  testOpts.headers['x-ow-version-lock'] = testVersionLock;
+}
+
+/**
+ * Processes the given queue concurrently. The handler functions can add more items to the queue
+ * if needed.
+ *
+ * @param {Array<*>} queue A list of tasks
+ * @param {function} fn A handler function `fn(task:any, queue:array, results:array)`
+ * @param {number} [maxConcurrent = 8] Concurrency level
+ * @returns the results
+ */
+async function processQueue(queue, fn, maxConcurrent = 8) {
+  const running = [];
+  const results = [];
+  while (queue.length || running.length) {
+    if (running.length < maxConcurrent && queue.length) {
+      const task = fn(queue.shift(), queue, results);
+      running.push(task);
+      task.finally(() => {
+        const idx = running.indexOf(task);
+        if (idx >= 0) {
+          running.splice(idx, 1);
+        }
+      });
+    } else {
+      // eslint-disable-next-line no-await-in-loop
+      await Promise.race(running);
+    }
   }
-  return data.text();
+  return results;
 }
 
 function getTestURLs(mostVisitedObj) {
@@ -57,49 +101,67 @@ async function getMostVisited() {
 }
 
 /**
- * function that turns most-visited pages into doms
+ * function that turns fetches the content of the most-visited pages
  */
 async function getTestSetup() {
   const mostVisitedUrls = await getMostVisited();
-  let originalDoms = [];
-  // construct array of promises from fetch
-  let testDoms = mostVisitedUrls.map((mostVisitedObj) => {
-    // eslint-disable-next-line camelcase
-    const { original: originalURL, test: testURL } = getTestURLs(mostVisitedObj);
 
-    // fetch page before change and page after change; and construct DOM
-    originalDoms.push(fetch(originalURL).then(getText));
-    return fetch(testURL).then(getText);
+  mostVisitedUrls.push({
+    req_url: 'https://theblog--adobe.hlx.page/en/publish/2019/11/22/asia-pacific-insiders-share-their-inspiration-from-max-2019.html',
   });
-  originalDoms = await Promise.all(originalDoms);
-  testDoms = await Promise.all(testDoms);
 
-  return {
-    originalDoms,
-    testDoms,
-    mostVisitedUrls,
-  };
+  // construct array of promises from fetch
+  return processQueue(mostVisitedUrls, async (mostVisitedObj, _, results) => {
+    const { original: originalURL, test: testURL } = getTestURLs(mostVisitedObj);
+    const ret = {
+      originalURL,
+      testURL,
+    };
+
+    {
+      console.log('fetching original', originalURL);
+      const res = await fetch(originalURL, origOpts);
+      ret.originalStatus = res.status;
+      ret.originalContent = await res.text();
+    }
+    {
+      console.log('fetching test', testURL);
+      const res = await fetch(testURL, testOpts);
+      ret.testStatus = res.status;
+      ret.testContent = await res.text();
+    }
+
+    results.push(ret);
+  }, 4);
 }
 
 describe('document equivalence', async () => {
   try {
     const setup = await getTestSetup();
 
-    setup.originalDoms.forEach((base, idx) => {
-      const { original: originalURL, test: testURL } = getTestURLs(setup.mostVisitedUrls[idx]);
+    setup.forEach((info) => {
+      const {
+        originalURL, originalContent, testURL, testContent,
+      } = info;
 
-      const orig_dom = new JSDOM(base).window.document;
+      const orig_dom = new JSDOM(originalContent).window.document;
 
-      const test_text = fixDomainInTestContent(setup.testDoms[idx]);
+      const test_text = fixDomainInTestContent(testContent);
       const test_dom = new JSDOM(test_text).window.document;
 
       describe(`Comparing ${originalURL} against ${testURL}`, () => {
         it('testing body node', () => {
+          if (info.testStatus !== 200) {
+            assert.fail(`${testURL} failed with ${info.testStatus}`);
+          }
           dumpDOM(orig_dom.body, test_dom.body);
           assertEquivalentNode(orig_dom.body, test_dom.body);
-        }).timeout(50000);
+        }).timeout(20000);
 
         it('testing head node', () => {
+          if (info.testStatus !== 200) {
+            assert.fail(`${testURL} failed with ${info.testStatus}`);
+          }
           dumpDOM(orig_dom.head, test_dom.head);
           assertEquivalentNode(orig_dom.head, test_dom.head);
         }).timeout(20000);
@@ -107,7 +169,6 @@ describe('document equivalence', async () => {
     });
   } catch (error) {
     // catch any error
-    // eslint-disable-next-line no-console
     console.error(`Cannot construct the tests: ${error.message}`, error);
     // radical exit to make the failure visible in the ci
     process.exit(1);


### PR DESCRIPTION
- clean up fetching of original and test content
- add fetch options for original and test
- use queue to only fetch 4 pages concurrently
- improve error handling and logging
- add support for `x-ow-version-lock` header to be passed via `$TEST_VERSION_LOCK`

- add 1 hard coded url from theblog.