### PR TITLE
feat(seo): support jpg as default meta image

### DIFF
--- a/src/html.pre.js
+++ b/src/html.pre.js
@@ -18,20 +18,25 @@ const { getAbsoluteUrl, wrapContent } = require('./utils.js');
  * @param action The action
  * @return The path to the default meta image
  */
-async function getDefaultMetaImage({ request, downloader }) {
-  const {
-    owner, repo, ref,
-  } = request.params || {};
-  const jpg = '/default-meta-image.jpg';
-  const png = '/default-meta-image.png';
-  const res = await downloader.fetchGithub({
-    owner,
-    repo,
-    ref,
-    path: jpg,
-    errorOn404: false,
-  });
-  return res.status === 200 ? jpg : png;
+async function getDefaultMetaImage(action) {
+  if (action) {
+    const { request, downloader } = action;
+    const {
+      owner, repo, ref,
+    } = request.params || {};
+    const path = '/default-meta-image.jpg';
+    const res = await downloader.fetchGithub({
+      owner,
+      repo,
+      ref,
+      path,
+      errorOn404: false,
+    });
+    if (res.status === 200) {
+      return path;
+    }
+  }
+  return '/default-meta-image.png';
 }
 
 /**

--- a/test/unit/html.pre.test.js
+++ b/test/unit/html.pre.test.js
@@ -22,6 +22,16 @@ const request = {
   },
   url: '/baz.html',
 };
+const action = {
+  request: {
+    owner: 'test',
+    repo: 'test',
+    ref: 'main',
+  },
+  downloader: {
+    fetchGithub: async () => ({ status: 200 }),
+  },
+};
 
 describe('Testing pre requirements for main function', () => {
   it('Exports pre', () => {
@@ -29,7 +39,7 @@ describe('Testing pre requirements for main function', () => {
   });
 
   it('pre is a function', () => {
-    assert.equal('function', typeof pre);
+    assert.strictEqual('function', typeof pre);
   });
 });
 
@@ -42,14 +52,14 @@ describe('Testing pre.js', () => {
       },
       request,
     };
-    pre(context);
+    pre(context, action);
 
     const div = dom.window.document.querySelector('div');
     assert.ok(div, 'A div must have been added');
-    assert.equal(div.innerHTML, '<h1>Title</h1>');
+    assert.strictEqual(div.innerHTML, '<h1>Title</h1>');
   });
 
-  it('Mutliline and text node body content is wrapped in a div', () => {
+  it('Multiline and text node body content is wrapped in a div', () => {
     const dom = new JSDOM(`<html><head><title>Foo</title></head><body>
       <h1>Title</h1>
       This is a text.
@@ -60,12 +70,12 @@ describe('Testing pre.js', () => {
       },
       request,
     };
-    pre(context);
+    pre(context, action);
 
     const div = dom.window.document.querySelector('div');
     assert.ok(div !== null, 'A div must have been added');
-    assert.equal(dom.window.document.body.childNodes.length, 1, 'Body must have only one child');
-    assert.equal(div.innerHTML, `
+    assert.strictEqual(dom.window.document.body.childNodes.length, 1, 'Body must have only one child');
+    assert.strictEqual(div.innerHTML, `
       <h1>Title</h1>
       This is a text.
     `);
@@ -82,7 +92,7 @@ describe('Testing pre.js', () => {
       },
       request,
     };
-    pre(context);
+    pre(context, action);
 
     const div = dom.window.document.querySelector('div');
     assert.ok(div.classList.contains('customcssclass'));
@@ -99,7 +109,7 @@ describe('Testing pre.js', () => {
       },
       request,
     };
-    pre(context);
+    pre(context, action);
 
     const div = dom.window.document.querySelector('div');
     assert.ok(div.classList.contains('customcssclass'));
@@ -117,7 +127,7 @@ describe('Testing pre.js', () => {
       },
       request,
     };
-    pre(context);
+    pre(context, action);
 
     const div = dom.window.document.querySelector('div');
     assert.ok(div.classList.contains('customcssclass'));
@@ -132,7 +142,7 @@ describe('Testing pre.js', () => {
       },
       request,
     };
-    pre(context);
+    pre(context, action);
 
     const div = dom.window.document.querySelector('div');
     assert.ok(div.classList.contains('customcssclass'));
@@ -159,10 +169,10 @@ describe('Testing pre.js', () => {
       },
       request,
     };
-    pre(context);
+    pre(context, action);
 
     assert.ok(context.content.meta.description);
-    assert.equal(context.content.meta.description, gt10Words);
+    assert.strictEqual(context.content.meta.description, gt10Words);
   });
 
   it('Meta description is truncated after 25 words', () => {
@@ -184,9 +194,9 @@ describe('Testing pre.js', () => {
       },
       request,
     };
-    pre(context);
+    pre(context, action);
 
-    assert.equal(context.content.meta.description.split(' ').length, 26); // 25 words + ...
+    assert.strictEqual(context.content.meta.description.split(' ').length, 26); // 25 words + ...
     assert.ok(context.content.meta.description.endsWith('...'));
   });
 
@@ -208,7 +218,7 @@ describe('Testing pre.js', () => {
       },
       request,
     };
-    pre(context);
+    pre(context, action);
 
     assert.strictEqual(context.content.meta.description, 'Lorem ipsum dolor sit amet, consectetuer adipiscing elit, sed diam nonummy nibh.'); // 25 words + ...
   });
@@ -222,9 +232,9 @@ describe('Testing pre.js', () => {
       },
       request,
     };
-    pre(context);
+    pre(context, action);
 
-    assert.equal(context.content.meta.url, `https://${request.headers['hlx-forwarded-host'].split(',')[0].trim()}${request.url}`);
+    assert.strictEqual(context.content.meta.url, `https://${request.headers['hlx-forwarded-host'].split(',')[0].trim()}${request.url}`);
   });
 
   it('Meta url uses host header if no hlx-forwarded-host available', () => {
@@ -243,9 +253,9 @@ describe('Testing pre.js', () => {
       },
       request: req,
     };
-    pre(context);
+    pre(context, action);
 
-    assert.equal(context.content.meta.url, `https://${req.headers.host}${req.url}`);
+    assert.strictEqual(context.content.meta.url, `https://${req.headers.host}${req.url}`);
   });
 
   it('Meta imageUrl uses content.image', () => {
@@ -258,9 +268,9 @@ describe('Testing pre.js', () => {
       },
       request,
     };
-    pre(context);
+    pre(context, action);
 
-    assert.equal(context.content.meta.imageUrl, context.content.image);
+    assert.strictEqual(context.content.meta.imageUrl, context.content.image);
   });
 
   it('Meta imageUrl uses content.image as absolute URL', () => {
@@ -273,12 +283,12 @@ describe('Testing pre.js', () => {
       },
       request,
     };
-    pre(context);
+    pre(context, action);
 
-    assert.equal(context.content.meta.imageUrl, `https://${request.headers['hlx-forwarded-host'].split(',')[0].trim()}${context.content.image}`);
+    assert.strictEqual(context.content.meta.imageUrl, `https://${request.headers['hlx-forwarded-host'].split(',')[0].trim()}${context.content.image}`);
   });
 
-  it('Meta imageUrl uses default meta image if no content.image available', () => {
+  it('Meta imageUrl uses JPG from repo if no content.image available', async () => {
     const dom = new JSDOM('<html></html>');
     const context = {
       content: {
@@ -287,9 +297,28 @@ describe('Testing pre.js', () => {
       },
       request,
     };
-    pre(context);
+    await pre(context, action);
 
-    assert.equal(context.content.meta.imageUrl, `https://${request.headers['hlx-forwarded-host'].split(',')[0].trim()}/default-meta-image.png`);
+    assert.strictEqual(context.content.meta.imageUrl, `https://${request.headers['hlx-forwarded-host'].split(',')[0].trim()}/default-meta-image.jpg`);
+  });
+
+  it('Meta imageUrl uses default meta image if neither content.image nor JPG from repo available', async () => {
+    const dom = new JSDOM('<html></html>');
+    const context = {
+      content: {
+        document: dom.window.document,
+        meta: {},
+      },
+      request,
+    };
+    await pre(context, {
+      ...action,
+      downloader: {
+        fetchGithub: async () => ({ status: 404 }),
+      },
+    });
+
+    assert.strictEqual(context.content.meta.imageUrl, `https://${request.headers['hlx-forwarded-host'].split(',')[0].trim()}/default-meta-image.png`);
   });
 
   it('Exposes body attributes as a map to be consumed in the HTL', () => {
@@ -309,14 +338,14 @@ describe('Testing pre.js', () => {
       },
       request,
     };
-    pre(context);
+    pre(context, action);
 
-    assert.deepEqual(dom.window.document.documentElement.attributesMap, {
+    assert.deepStrictEqual(dom.window.document.documentElement.attributesMap, {
       class: 'foo',
       bar: 'baz',
       'data-qux': 'corge',
     });
-    assert.deepEqual(dom.window.document.body.attributesMap, {
+    assert.deepStrictEqual(dom.window.document.body.attributesMap, {
       class: 'grault',
       garply: 'waldo',
       'data-fred': 'plugh',


### PR DESCRIPTION
Fix #411 

Backward compatible way to support JPG as default meta image. The logic is now:
- `helix-pipeline` tries to extract a suitable image from the content
- _[NEW]_ if no meta image was found in the content, look for a `default-meta-image.jpg` in the repo
- fall back to `default-meta-image.png`
- if the repo doesn't have its own `default-meta-image.png` overlay , [this one](https://www.hlx.page/default-meta-image.png) from `helix-pages` will be served