### PR TITLE
feat(seo): add fastly io params to meta image url

### DIFF
--- a/src/html.pre.js
+++ b/src/html.pre.js
@@ -89,8 +89,8 @@ async function pre(context, action) {
   });
   meta.description = `${desc.slice(0, 25).join(' ')}${desc.length > 25 ? ' ...' : ''}`;
   meta.url = getAbsoluteUrl(request.headers, request.url);
-  meta.imageUrl = getAbsoluteUrl(request.headers,
-    content.image || await getDefaultMetaImage(action));
+  meta.imageUrl = `${content.image || await getDefaultMetaImage(action)}?auto=webp&format=pjpg&optimize=medium&width=1200`;
+  meta.imageUrl = getAbsoluteUrl(request.headers, meta.imageUrl);
 }
 
 module.exports.pre = pre;

--- a/test/unit/html.pre.test.js
+++ b/test/unit/html.pre.test.js
@@ -270,7 +270,7 @@ describe('Testing pre.js', () => {
     };
     pre(context, action);
 
-    assert.strictEqual(context.content.meta.imageUrl, context.content.image);
+    assert.strictEqual(context.content.meta.imageUrl, `${context.content.image}?auto=webp&format=pjpg&optimize=medium&width=1200`);
   });
 
   it('Meta imageUrl uses content.image as absolute URL', () => {
@@ -285,7 +285,7 @@ describe('Testing pre.js', () => {
     };
     pre(context, action);
 
-    assert.strictEqual(context.content.meta.imageUrl, `https://${request.headers['hlx-forwarded-host'].split(',')[0].trim()}${context.content.image}`);
+    assert.strictEqual(context.content.meta.imageUrl, `https://${request.headers['hlx-forwarded-host'].split(',')[0].trim()}${context.content.image}?auto=webp&format=pjpg&optimize=medium&width=1200`);
   });
 
   it('Meta imageUrl uses JPG from repo if no content.image available', async () => {
@@ -299,7 +299,7 @@ describe('Testing pre.js', () => {
     };
     await pre(context, action);
 
-    assert.strictEqual(context.content.meta.imageUrl, `https://${request.headers['hlx-forwarded-host'].split(',')[0].trim()}/default-meta-image.jpg`);
+    assert.strictEqual(context.content.meta.imageUrl, `https://${request.headers['hlx-forwarded-host'].split(',')[0].trim()}/default-meta-image.jpg?auto=webp&format=pjpg&optimize=medium&width=1200`);
   });
 
   it('Meta imageUrl uses default meta image if neither content.image nor JPG from repo available', async () => {
@@ -318,7 +318,7 @@ describe('Testing pre.js', () => {
       },
     });
 
-    assert.strictEqual(context.content.meta.imageUrl, `https://${request.headers['hlx-forwarded-host'].split(',')[0].trim()}/default-meta-image.png`);
+    assert.strictEqual(context.content.meta.imageUrl, `https://${request.headers['hlx-forwarded-host'].split(',')[0].trim()}/default-meta-image.png?auto=webp&format=pjpg&optimize=medium&width=1200`);
   });
 
   it('Exposes body attributes as a map to be consumed in the HTL', () => {


### PR DESCRIPTION
Fix #541 