### PR TITLE
Remove optional & production from hostname label in sidekick

### DIFF
--- a/tools/sidekick/index.md
+++ b/tools/sidekick/index.md
@@ -8,7 +8,7 @@ id: form
 
 <label for="giturl">Repository URL:</label>
 <input id="giturl" placeholder="https://github.com/....">
-<label for="host">Production Hostname (optional): </label>
+<label for="host">Hostname: </label>
 <input id="host">
 <label for="project">Project Name (optional): </label>
 <input id="project">


### PR DESCRIPTION
Sidekick was only working for me on the docs pages and not on the webpage itself (sidekick came up empty). Turns out that a host must be provided during the creation of the bookmarklet for it to work on webpages. 

The sidekick creation page had the words `Optional` and `Production` which threw me off when creating the bookmarklet and I never entered a value. This PR just removes those words.