### PR TITLE
feat(sidekick): allow loading plugins from a fixed host

### DIFF
--- a/test/unit/sidekick/config-plugin-host.html
+++ b/test/unit/sidekick/config-plugin-host.html
@@ -1,0 +1,16 @@
+<html>
+  <head>
+    <meta charset="utf-8"/>
+  </head>
+  <body>
+    <script>
+      window.hlxSidekickConfig = {
+        owner: 'adobe',
+        repo: 'theblog',
+        ref: 'foo',
+        pluginHost: 'https://plugins.foo.bar',
+      };
+    </script>
+    <script src="../../../tools/sidekick/app.js"></script>
+  </body>
+</html>

--- a/tools/sidekick/app.js
+++ b/tools/sidekick/app.js
@@ -371,7 +371,7 @@
         this.config.plugins.forEach((plugin) => this.add(plugin));
       }
       if ((this.isHelix() || this.isEditor()) && this.config.innerHost) {
-        const prefix = this.isEditor() ? `https://${this.config.innerHost}` : '';
+        const prefix = this.config.pluginHost || this.isEditor() ? `https://${this.config.innerHost}` : '';
         appendTag(document.head, {
           tag: 'script',
           attrs: {

--- a/tools/sidekick/app.js
+++ b/tools/sidekick/app.js
@@ -370,8 +370,9 @@
       if (this.config.plugins && Array.isArray(this.config.plugins)) {
         this.config.plugins.forEach((plugin) => this.add(plugin));
       }
-      if ((this.isHelix() || this.isEditor()) && this.config.innerHost) {
-        const prefix = this.config.pluginHost || this.isEditor() ? `https://${this.config.innerHost}` : '';
+      if ((this.isHelix() || this.isEditor())
+        && (this.config.pluginHost || this.config.innerHost)) {
+        const prefix = this.config.pluginHost || (this.isEditor() ? `https://${this.config.innerHost}` : '');
         appendTag(document.head, {
           tag: 'script',
           attrs: {


### PR DESCRIPTION
This allows developers to load plugins from localhost during development, and customers to reuse centrally hosted plugins across multiple projects.