### PR TITLE
test(smoke): retry smoke tests three times

### DIFF
--- a/test/smoke/homepage.smoke.js
+++ b/test/smoke/homepage.smoke.js
@@ -51,9 +51,25 @@ describe('homepage smoke tests - subdomain extraction and some page content', ()
   }
 
   async function testHomePage(url) {
-    const res = await chai.request(url)
-      .get('/')
-      .set('X-Debug', argv.serviceid || false);
+    let retries = 3;
+    let res;
+
+    // try three times in case we get an on/off 504 error
+    while (retries > 0) {
+      retries -= 1;
+      // eslint-disable-next-line no-await-in-loop
+      res = await chai.request(url)
+        .get('/')
+        .set('X-Debug', argv.serviceid || false);
+      try {
+        expect(res).to.have.status(200);
+        break;
+      } catch (e) {
+        if (retries <= 0) {
+          throw e;
+        }
+      }
+    }
 
     console.log(res.headers);
     expect(res).to.have.status(200);


### PR DESCRIPTION
we are often seeing intermittent failures in the smoke tests because the smoke test action is not ready yet or times out. This is a simple fix that will retry each request up to three times, to increase the chance of a 200 so that we don't have to wait another 5 minutes to run the entire test suite just because one request failed.