### PR TITLE
chore(cfg): enable universal strain and preflights

### DIFF
--- a/helix-config.yaml
+++ b/helix-config.yaml
@@ -8,8 +8,7 @@ definitions:
     # default repository. set to git remote repository before deployment
     - &defaultRepo https://github.com/adobe/helix-pages.git#master
 
-# preflight requests cause problems with ESI... disabling for now
-# preflight: https://adobeioruntime.net/api/v1/web/helix/helix-services/version-picker@v1
+preflight: https://adobeioruntime.net/api/v1/web/helix/helix-services/version-picker@v1
 
 strains:
   - name: default
@@ -18,16 +17,14 @@ strains:
     static: https://github.com/adobe/helix-pages.git/htdocs#master
     package: helix-pages/pages_4.15.4
 
-  # disabled for now until test-request works
-  #
-  # - name: universal
-  #   code: *defaultRepo
-  #   content: https://github.com/adobe/helix-pages.git#master
-  #   static: https://github.com/adobe/helix-pages.git/htdocs#master
-  #   # universal runtime, using the helix test deployment subdomain for now.
-  #   package: https://deploy-test.anywhere.run/pages_4.15.4
-  #   version-lock:
-  #     env: amazonwebservices
+  - name: universal
+    code: *defaultRepo
+    content: https://github.com/adobe/helix-pages.git#master
+    static: https://github.com/adobe/helix-pages.git/htdocs#master
+    # universal runtime, using the helix test deployment subdomain for now.
+    package: https://deploy-test.anywhere.run/pages_4.15.4
+    version-lock:
+      env: amazonwebservices
 
   - name: breaking-202103
     condition:

--- a/release/deploy-ci.sh
+++ b/release/deploy-ci.sh
@@ -27,4 +27,4 @@ if [[ -f ".pages-package.env" ]]; then
 fi
 
 # update helix-config.yaml
-node ./release/update-config.js --pkgVersion ci$CIRCLE_BUILD_NUM
+node ./release/update-config.js --pkgVersion ci$CIRCLE_BUILD_NUM --strain default --strain universal

--- a/release/deploy.sh
+++ b/release/deploy.sh
@@ -12,14 +12,34 @@
 #
 set -veo pipefail
 
+if [ -n "$(git status --porcelain)" ]; then
+  echo "directory not clean."
+  exit 1
+fi
+
+# ensure latest version
+git fetch
+
+BRANCH="$(git branch --show-current)"
+PKG_VERSION=""
+ARG_VERSION=""
+ARG_STRAIN="--strain default --strain universal"
+if [[ "$BRANCH" =~ ^breaking-.* ]]; then
+  # use special version for deploying on breaking branch
+  PKG_VERSION="$(jq -r .version package.json).$BRANCH"
+  ARG_VERSION="--pkgVersion $PKG_VERSION"
+  ARG_STRAIN="--strain $BRANCH"
+  echo "using package version: $PKG_VERSION"
+fi
+
 hlx clean
 hlx build --universal
-hedy -v --target=wsk,aws --deploy --entry-file=.hlx/build/src/html.js       --property.scriptName=html
-hedy -v --target=wsk,aws --deploy --entry-file=.hlx/build/src/embed_html.js --property.scriptName=embed_html
-hedy -v --target=wsk,aws --deploy --entry-file=.hlx/build/src/idx_json.js   --property.scriptName=idx_json
-hedy -v --target=wsk,aws --deploy --entry-file=.hlx/build/src/plain_html.js --property.scriptName=plain_html
-hedy -v --target=wsk,aws --deploy --entry-file=./cgi-bin/feed.js            --property.scriptName=cgi-bin-feed    --test='?src=/en/query-index.json%3Flimit=1&id=path&title=title&updated=date&originalHost=blog.adobe.com'
-hedy -v --target=wsk,aws --deploy --entry-file=./cgi-bin/sitemap.js         --property.scriptName=cgi-bin-sitemap --test='?__hlx_owner=adobe&__hlx_repo=pages&__hlx_ref=master'
+hedy -v --target=wsk,aws --deploy --entry-file=.hlx/build/src/html.js       $ARG_VERSION --property.scriptName=html
+hedy -v --target=wsk,aws --deploy --entry-file=.hlx/build/src/embed_html.js $ARG_VERSION --property.scriptName=embed_html
+hedy -v --target=wsk,aws --deploy --entry-file=.hlx/build/src/idx_json.js   $ARG_VERSION --property.scriptName=idx_json
+hedy -v --target=wsk,aws --deploy --entry-file=.hlx/build/src/plain_html.js $ARG_VERSION --property.scriptName=plain_html
+hedy -v --target=wsk,aws --deploy --entry-file=./cgi-bin/feed.js            $ARG_VERSION --property.scriptName=cgi-bin-feed    --test='?src=/en/query-index.json%3Flimit=1&id=path&title=title&updated=date&originalHost=blog.adobe.com'
+hedy -v --target=wsk,aws --deploy --entry-file=./cgi-bin/sitemap.js         $ARG_VERSION --property.scriptName=cgi-bin-sitemap --test='?__hlx_owner=adobe&__hlx_repo=pages&__hlx_ref=master'
 
 # update package secrets
 if [[ -f ".pages-package.env" ]]; then
@@ -27,4 +47,4 @@ if [[ -f ".pages-package.env" ]]; then
 fi
 
 # update helix-config.yaml
-node ./release/update-config.js
+node ./release/update-config.js $ARG_VERSION $ARG_STRAIN

--- a/release/update-config.js
+++ b/release/update-config.js
@@ -32,22 +32,30 @@ async function saveConfig(cfg) {
 
 async function run() {
   let { version } = pkgJson;
+  const strains = [];
   let i = 2;
   while (i < process.argv.length) {
     switch (process.argv[i++]) {
       case '--pkgVersion':
         version = process.argv[i++];
         break;
+      case '--strain':
+        strains.push(process.argv[i++]);
+        break;
       default:
         throw new Error('unknown option: ', process.argv[i - 1]);
     }
+  }
+
+  if (!strains.length) {
+    strains.push('default');
   }
 
   const cfg = await new HelixConfig()
     .withConfigPath(path.resolve(__dirname, '..', 'helix-config.yaml'))
     .init();
 
-  const affected = [cfg.strains.get('default')];
+  const affected = strains.map((s) => cfg.strains.get(s));
   let modified = false;
 
   // update package in affected strains


### PR DESCRIPTION
fixes #675

Note: I marked it as `chore` so that we don't deploy a new helix pages version. once merged into master, I will publish manually to fastly.