### PR TITLE
test(sidekick): add delay to load css test

### DIFF
--- a/test/unit/sidekick.test.js
+++ b/test/unit/sidekick.test.js
@@ -62,11 +62,7 @@ describe('Test sidekick bookmarklet', () => {
     });
   };
 
-  const assertLater = async (delay = 3000) => new Promise((resolve) => {
-    setTimeout(() => {
-      resolve(assert);
-    }, delay);
-  });
+  const sleep = async (delay = 1000) => new Promise((resolve) => setTimeout(resolve, delay));
 
   let browser;
   let page;
@@ -246,7 +242,8 @@ describe('Test sidekick bookmarklet', () => {
     });
     const bgColor = await page.$eval('div.hlx-sk',
       (elem) => window.getComputedStyle(elem).getPropertyValue('background-color'));
-    (await assertLater()).strictEqual(bgColor, 'rgb(255, 255, 0)', 'Did not load custom CSS');
+    await sleep(3000);
+    assert.strictEqual(bgColor, 'rgb(255, 255, 0)', 'Did not load custom CSS');
   }).timeout(IT_DEFAULT_TIMEOUT);
 
   it('Shows and hides notifications', async () => {

--- a/test/unit/sidekick.test.js
+++ b/test/unit/sidekick.test.js
@@ -62,6 +62,12 @@ describe('Test sidekick bookmarklet', () => {
     });
   };
 
+  const assertLater = async (delay = 3000) => new Promise((resolve) => {
+    setTimeout(() => {
+      resolve(assert);
+    }, delay);
+  });
+
   let browser;
   let page;
 
@@ -240,7 +246,7 @@ describe('Test sidekick bookmarklet', () => {
     });
     const bgColor = await page.$eval('div.hlx-sk',
       (elem) => window.getComputedStyle(elem).getPropertyValue('background-color'));
-    assert.strictEqual(bgColor, 'rgb(255, 255, 0)', 'Did not load custom CSS');
+    (await assertLater()).strictEqual(bgColor, 'rgb(255, 255, 0)', 'Did not load custom CSS');
   }).timeout(IT_DEFAULT_TIMEOUT);
 
   it('Shows and hides notifications', async () => {


### PR DESCRIPTION
Prevent errors like https://app.circleci.com/pipelines/github/adobe/helix-pages/3049/workflows/f9b539a9-8262-4d6a-9fa6-096261355891/jobs/13875