### PR TITLE
chore(test): Another attempt to make the Sidekick tests more reliable

### DIFF
--- a/test/unit/sidekick.test.js
+++ b/test/unit/sidekick.test.js
@@ -528,6 +528,8 @@ describe('Test sidekick bookmarklet', () => {
       // click publish button
       await execPlugin(page, 'publish');
     }));
+
+    await sleep(3000);
     // check result
     assert.deepStrictEqual(allPurged, toPurge.concat(toPurge).reverse(), 'Purge request not sent');
   }).timeout(IT_DEFAULT_TIMEOUT);


### PR DESCRIPTION
Response to recent new Sidekick failing tests:
```
1 test failed out of 60
Test sidekick bookmarklet Publish thoroughly purges directories