### PR TITLE
improve universal deployment

### DIFF
--- a/helix-config.yaml
+++ b/helix-config.yaml
@@ -24,7 +24,22 @@ strains:
     # universal runtime, using the helix test deployment subdomain for now.
     package: https://deploy-test.anywhere.run/pages_4.16.5
     version-lock:
+      # pinned to AWS, use the other strains to switch runtimes dynamically
       env: amazonwebservices
+
+  - name: universal-ci
+    code: *defaultRepo
+    content: https://github.com/adobe/helix-pages.git#master
+    static: https://github.com/adobe/helix-pages.git/htdocs#master
+    # universal runtime, using the helix-pages-ci subdomain
+    package: https://helix-pages-ci.anywhere.run/pages_4.16.5
+
+  - name: universal-prod
+    code: *defaultRepo
+    content: https://github.com/adobe/helix-pages.git#master
+    static: https://github.com/adobe/helix-pages.git/htdocs#master
+    # universal runtime, using the helix-pages subdomain
+    package: https://helix-pages.anywhere.run/pages_4.16.5
 
   - name: breaking-202103
     condition:

--- a/package-lock.json
+++ b/package-lock.json
@@ -51,9 +51,9 @@
       }
     },
     "@adobe/helix-deploy": {
-      "version": "3.0.18",
-      "resolved": "https://registry.npmjs.org/@adobe/helix-deploy/-/helix-deploy-3.0.18.tgz",
-      "integrity": "sha512-zUL4kYxmRIMgYPkniF7girKEu9xJFu4ZC4Z6ax9CAbhLDHZbUgg1r96+asCGtwyJsQMVVh7xwmwjnfDWW0X9sA==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@adobe/helix-deploy/-/helix-deploy-3.1.0.tgz",
+      "integrity": "sha512-4583wq2HudhS7ctIzsou3ndslEVVOmorwhHpOBEN0AgRnBb5jE0ajSXFuV+k90Uf+2LFQ0Vl5rKkHlWENoQTIw==",
       "dev": true,
       "requires": {
         "@adobe/fastly-native-promises": "1.19.12",
@@ -4890,9 +4890,9 @@
       }
     },
     "electron-to-chromium": {
-      "version": "1.3.665",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.665.tgz",
-      "integrity": "sha512-LIjx1JheOz7LM8DMEQ2tPnbBzJ4nVG1MKutsbEMLnJfwfVdPIsyagqfLp56bOWhdBrYGXWHaTayYkllIU2TauA==",
+      "version": "1.3.667",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.667.tgz",
+      "integrity": "sha512-Ot1pPtAVb5nd7jeVF651zmfLFilRVFomlDzwXmdlWe5jyzOGa6mVsQ06XnAurT7wWfg5VEIY+LopbAdD/bpo5w==",
       "dev": true
     },
     "emitter-listener": {

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
   },
   "devDependencies": {
     "@adobe/eslint-config-helix": "1.1.3",
-    "@adobe/helix-deploy": "3.0.18",
+    "@adobe/helix-deploy": "3.1.0",
     "@semantic-release/changelog": "5.0.1",
     "@semantic-release/exec": "5.0.0",
     "@semantic-release/git": "9.0.0",

--- a/release/deploy-ci.sh
+++ b/release/deploy-ci.sh
@@ -14,7 +14,9 @@ set -veo pipefail
 
 hlx clean
 hlx build --universal
-hedy -v --target=wsk,aws --deploy --entry-file=.hlx/build/src/html.js       --pkgVersion=ci$CIRCLE_BUILD_NUM --property.scriptName=html        --fastly-service-id 0trc7KZPj73TyFfFhsUyWu # initialize gateway
+hedy -v --target=wsk,aws --deploy --entry-file=.hlx/build/src/html.js       --pkgVersion=ci$CIRCLE_BUILD_NUM --property.scriptName=html \
+      --fastly-service-id 0trc7KZPj73TyFfFhsUyWu \ # hardcoded fastly namespace
+      --checkpath /_status_check/healthcheck.json  # hardcoded health check path
 echo "Gateway Updated."
 hedy -v --target=wsk,aws --deploy --entry-file=.hlx/build/src/embed_html.js --pkgVersion=ci$CIRCLE_BUILD_NUM --property.scriptName=embed_html
 hedy -v --target=wsk,aws --deploy --entry-file=.hlx/build/src/idx_json.js   --pkgVersion=ci$CIRCLE_BUILD_NUM --property.scriptName=idx_json

--- a/release/deploy-ci.sh
+++ b/release/deploy-ci.sh
@@ -15,7 +15,7 @@ set -veo pipefail
 hlx clean
 hlx build --universal
 hedy -v --target=wsk,aws --deploy --entry-file=.hlx/build/src/html.js       --pkgVersion=ci$CIRCLE_BUILD_NUM --property.scriptName=html \
-      --fastly-service-id 0trc7KZPj73TyFfFhsUyWu \ # hardcoded fastly namespace
+      --fastly-service-id 0trc7KZPj73TyFfFhsUyWu \
       --checkpath /_status_check/healthcheck.json  # hardcoded health check path
 echo "Gateway Updated."
 hedy -v --target=wsk,aws --deploy --entry-file=.hlx/build/src/embed_html.js --pkgVersion=ci$CIRCLE_BUILD_NUM --property.scriptName=embed_html

--- a/release/deploy-ci.sh
+++ b/release/deploy-ci.sh
@@ -14,7 +14,7 @@ set -veo pipefail
 
 hlx clean
 hlx build --universal
-hedy -v --target=wsk,aws --deploy --entry-file=.hlx/build/src/html.js       --pkgVersion=ci$CIRCLE_BUILD_NUM --property.scriptName=html
+hedy -v --target=wsk,aws --deploy --entry-file=.hlx/build/src/html.js       --pkgVersion=ci$CIRCLE_BUILD_NUM --property.scriptName=html        --fastly-service-id 0trc7KZPj73TyFfFhsUyWu # initialize gateway
 hedy -v --target=wsk,aws --deploy --entry-file=.hlx/build/src/embed_html.js --pkgVersion=ci$CIRCLE_BUILD_NUM --property.scriptName=embed_html
 hedy -v --target=wsk,aws --deploy --entry-file=.hlx/build/src/idx_json.js   --pkgVersion=ci$CIRCLE_BUILD_NUM --property.scriptName=idx_json
 hedy -v --target=wsk,aws --deploy --entry-file=.hlx/build/src/plain_html.js --pkgVersion=ci$CIRCLE_BUILD_NUM --property.scriptName=plain_html

--- a/release/deploy-ci.sh
+++ b/release/deploy-ci.sh
@@ -15,6 +15,7 @@ set -veo pipefail
 hlx clean
 hlx build --universal
 hedy -v --target=wsk,aws --deploy --entry-file=.hlx/build/src/html.js       --pkgVersion=ci$CIRCLE_BUILD_NUM --property.scriptName=html        --fastly-service-id 0trc7KZPj73TyFfFhsUyWu # initialize gateway
+echo "Gateway Updated."
 hedy -v --target=wsk,aws --deploy --entry-file=.hlx/build/src/embed_html.js --pkgVersion=ci$CIRCLE_BUILD_NUM --property.scriptName=embed_html
 hedy -v --target=wsk,aws --deploy --entry-file=.hlx/build/src/idx_json.js   --pkgVersion=ci$CIRCLE_BUILD_NUM --property.scriptName=idx_json
 hedy -v --target=wsk,aws --deploy --entry-file=.hlx/build/src/plain_html.js --pkgVersion=ci$CIRCLE_BUILD_NUM --property.scriptName=plain_html

--- a/release/deploy-ci.sh
+++ b/release/deploy-ci.sh
@@ -15,7 +15,7 @@ set -veo pipefail
 hlx clean
 hlx build --universal
 hedy -v --target=wsk,aws --deploy --entry-file=.hlx/build/src/html.js       --pkgVersion=ci$CIRCLE_BUILD_NUM --property.scriptName=html \
-      --fastly-service-id 0trc7KZPj73TyFfFhsUyWu \
+      --fastly-service-id 3F0xJzfyehcX3g3DQGubj9 \
       --checkpath /_status_check/healthcheck.json  # hardcoded health check path
 echo "Gateway Updated."
 hedy -v --target=wsk,aws --deploy --entry-file=.hlx/build/src/embed_html.js --pkgVersion=ci$CIRCLE_BUILD_NUM --property.scriptName=embed_html

--- a/release/deploy.sh
+++ b/release/deploy.sh
@@ -34,7 +34,9 @@ fi
 
 hlx clean
 hlx build --universal
-hedy -v --target=wsk,aws --deploy --entry-file=.hlx/build/src/html.js       $ARG_VERSION --property.scriptName=html         --fastly-service-id 0trc7KZPj73TyFfFhsUyWu # initialize gateway
+hedy -v --target=wsk,aws --deploy --entry-file=.hlx/build/src/html.js       --pkgVersion=ci$CIRCLE_BUILD_NUM --property.scriptName=html \
+      --fastly-service-id 0trc7KZPj73TyFfFhsUyWu \
+      --checkpath /_status_check/healthcheck.json  # hardcoded health check path
 echo "Gateway Updated."
 hedy -v --target=wsk,aws --deploy --entry-file=.hlx/build/src/embed_html.js $ARG_VERSION --property.scriptName=embed_html
 hedy -v --target=wsk,aws --deploy --entry-file=.hlx/build/src/idx_json.js   $ARG_VERSION --property.scriptName=idx_json

--- a/release/deploy.sh
+++ b/release/deploy.sh
@@ -35,6 +35,7 @@ fi
 hlx clean
 hlx build --universal
 hedy -v --target=wsk,aws --deploy --entry-file=.hlx/build/src/html.js       $ARG_VERSION --property.scriptName=html         --fastly-service-id 0trc7KZPj73TyFfFhsUyWu # initialize gateway
+echo "Gateway Updated."
 hedy -v --target=wsk,aws --deploy --entry-file=.hlx/build/src/embed_html.js $ARG_VERSION --property.scriptName=embed_html
 hedy -v --target=wsk,aws --deploy --entry-file=.hlx/build/src/idx_json.js   $ARG_VERSION --property.scriptName=idx_json
 hedy -v --target=wsk,aws --deploy --entry-file=.hlx/build/src/plain_html.js $ARG_VERSION --property.scriptName=plain_html

--- a/release/deploy.sh
+++ b/release/deploy.sh
@@ -34,7 +34,7 @@ fi
 
 hlx clean
 hlx build --universal
-hedy -v --target=wsk,aws --deploy --entry-file=.hlx/build/src/html.js       $ARG_VERSION --property.scriptName=html
+hedy -v --target=wsk,aws --deploy --entry-file=.hlx/build/src/html.js       $ARG_VERSION --property.scriptName=html         --fastly-service-id 0trc7KZPj73TyFfFhsUyWu # initialize gateway
 hedy -v --target=wsk,aws --deploy --entry-file=.hlx/build/src/embed_html.js $ARG_VERSION --property.scriptName=embed_html
 hedy -v --target=wsk,aws --deploy --entry-file=.hlx/build/src/idx_json.js   $ARG_VERSION --property.scriptName=idx_json
 hedy -v --target=wsk,aws --deploy --entry-file=.hlx/build/src/plain_html.js $ARG_VERSION --property.scriptName=plain_html


### PR DESCRIPTION
This PR creates two new strains, each using a different gateway host (`helix-pages.anywhere.run` and `helix-pages-ci.anywhere.run`) that will dynamically switch between runtimes.

The old `universal` strain stays as is