### PR TITLE
fix: re-enable http/2

### DIFF
--- a/cgi-bin/feed.js
+++ b/cgi-bin/feed.js
@@ -12,8 +12,6 @@
 const fetchAPI = require('@adobe/helix-fetch');
 const escape = require('xml-escape');
 
-process.env.HELIX_FETCH_FORCE_HTTP1 = true;
-
 function createFetchContext() {
   /* istanbul ignore next */
   if (process.env.HELIX_FETCH_FORCE_HTTP1) {


### PR DESCRIPTION
As a precautionary measure HTTP/2 had been disabled in order to avoid issues related to the runtime migration to Azure. We've since re-implemented the http client (fetch) and now it's time to re-enable HTTP/2.