### PR TITLE
ci(integration): store results of hlx publish command as junit.xml

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -134,19 +134,36 @@ jobs:
           command: |
             if [[ $CIRCLE_BRANCH == *"-publish-ci"* ]]; then
                 echo "Using CI Publish"
-                npx hlx publish --custom-vcl='vcl/extensions.vcl' --fastly-serviceid $TEST_SERVICE --api-publish  https://adobeioruntime.net/api/v1/web/helix/helix-services/publish@ci | cat
+                npx hlx publish --custom-vcl='vcl/extensions.vcl' --fastly-serviceid $TEST_SERVICE --api-publish  https://adobeioruntime.net/api/v1/web/helix/helix-services/publish@ci 2>&1 | tee publish.out
             else
               if [[ ! -z "<< pipeline.parameters.publish_ci_version >>" ]]; then
                 echo "Using CI Publish provided version: << pipeline.parameters.publish_ci_version >>"
-                npx hlx publish --custom-vcl='vcl/extensions.vcl' --fastly-serviceid $TEST_SERVICE --api-publish  https://adobeioruntime.net/api/v1/web/helix/helix-services/publish@<< pipeline.parameters.publish_ci_version >> | cat
+                npx hlx publish --custom-vcl='vcl/extensions.vcl' --fastly-serviceid $TEST_SERVICE --api-publish  https://adobeioruntime.net/api/v1/web/helix/helix-services/publish@<< pipeline.parameters.publish_ci_version >> 2>&1 | tee publish.out
               else
                 echo "Using regular Publish"
-                npx hlx publish --custom-vcl='vcl/extensions.vcl' --fastly-serviceid $TEST_SERVICE | cat
+                npx hlx publish --custom-vcl='vcl/extensions.vcl' --fastly-serviceid $TEST_SERVICE 2>&1 | tee publish.out
               fi
             fi
 
-
       - run: mkdir junit
+
+      - run:
+          name: Store Publish Output as junit results
+          command: |
+            if grep "Error" publish.out; then
+              echo '<?xml version="1.0" encoding="UTF-8" ?>'                                           > junit/publish-as-test.xml
+              echo '<testsuites id="publish" name="hlx publish" tests="1" failures="1" time="0.000">' >> junit/publish-as-test.xml
+              echo '<testsuite id="publish1" name="hlx publish" tests="1" failures="1" time="0.001">' >> junit/publish-as-test.xml
+              echo '<testcase id="publish2" name="run hlx publish" time="0.001">                      >> junit/publish-as-test.xml
+              echo '<failure message="hlx publish failed with error" type="WARNING">'                 >> junit/publish-as-test.xml
+              cat publish.out                                                                         >> junit/publish-as-test.xml
+              echo '</failure>'                                                                       >> junit/publish-as-test.xml
+              echo '</testcase>'                                                                      >> junit/publish-as-test.xml
+              echo '</testsuite>'                                                                     >> junit/publish-as-test.xml
+              echo '</testsuites>'                                                                    >> junit/publish-as-test.xml
+            fi
+      - store_test_results:
+          path: junit
 
       - persist_to_workspace:
           root: /home/circleci

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -154,7 +154,7 @@ jobs:
               echo '<?xml version="1.0" encoding="UTF-8" ?>'                                           > junit/publish-as-test.xml
               echo '<testsuites id="publish" name="hlx publish" tests="1" failures="1" time="0.000">' >> junit/publish-as-test.xml
               echo '<testsuite id="publish1" name="hlx publish" tests="1" failures="1" time="0.001">' >> junit/publish-as-test.xml
-              echo '<testcase id="publish2" name="run hlx publish" time="0.001">                      >> junit/publish-as-test.xml
+              echo '<testcase id="publish2" name="run hlx publish" time="0.001">'                     >> junit/publish-as-test.xml
               echo '<failure message="hlx publish failed with error" type="WARNING">'                 >> junit/publish-as-test.xml
               cat publish.out                                                                         >> junit/publish-as-test.xml
               echo '</failure>'                                                                       >> junit/publish-as-test.xml


### PR DESCRIPTION
so that we can pull it automatically in workflows that are calling the integration tests via API
