### PR TITLE
chore(deps): downgrade pipeline until other building blocks are ready

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
   "homepage": "https://github.com/adobe/helix-pages#readme",
   "dependencies": {
     "@adobe/helix-fetch": "2.1.6",
-    "@adobe/helix-pipeline": "13.7.4",
+    "@adobe/helix-pipeline": "13.6.20",
     "@adobe/helix-shared": "7.20.0",
     "@adobe/htlengine": "6.3.7",
     "@adobe/openwhisk-action-logger": "2.4.1",


### PR DESCRIPTION
New pipeline step will start caching md/docx files, but we currently have no customer accessible mechanism to purge this cache when previewing.

see https://github.com/adobe/helix-pages/pull/720