### PR TITLE
feat(blob): adjust to rootless image paths

### DIFF
--- a/src/extract-metadata.js
+++ b/src/extract-metadata.js
@@ -52,14 +52,21 @@ function readBlockConfig($block) {
 }
 
 /**
- * Adds image optimization parameters suitable for meta images to a path.
- * @param {string} path The image path
- * @returns The optimized image path
+ * Adds image optimization parameters suitable for meta images to a URL.
+ * @param {string} url The image URL
+ * @returns The optimized image URL
  */
-function optimizeMetaImage(path) {
-  return (path.startsWith('/') || path.startsWith('./'))
-    ? `${path.split('?')[0]}?auto=webp&format=pjpg&optimize=medium&width=1200`
-    : path;
+function optimizeMetaImage(url) {
+  if (typeof url !== 'string') {
+    return null;
+  }
+  if (url.startsWith('./')) {
+    // eslint-disable-next-line no-param-reassign
+    url = url.substring(1);
+  }
+  return url.startsWith('/')
+    ? `${url.split('?')[0]}?auto=webp&format=pjpg&optimize=medium&width=1200`
+    : url;
 }
 
 /**

--- a/src/extract-metadata.js
+++ b/src/extract-metadata.js
@@ -53,20 +53,22 @@ function readBlockConfig($block) {
 
 /**
  * Adds image optimization parameters suitable for meta images to a URL.
- * @param {string} url The image URL
+ * @param {string} pagePath The path of the requested page
+ * @param {string} imgUrl The image URL
  * @returns The optimized image URL
  */
-function optimizeMetaImage(url) {
-  if (typeof url !== 'string') {
+function optimizeMetaImage(pagePath, imgUrl) {
+  if (typeof imgUrl !== 'string') {
     return null;
   }
-  if (url.startsWith('./')) {
+  if (imgUrl.startsWith('./')) {
+    // resolve relative image path using page path
     // eslint-disable-next-line no-param-reassign
-    url = url.substring(1);
+    imgUrl = `${pagePath.substring(0, pagePath.lastIndexOf('/'))}${imgUrl.substring(1)}`;
   }
-  return url.startsWith('/')
-    ? `${url.split('?')[0]}?auto=webp&format=pjpg&optimize=medium&width=1200`
-    : url;
+  return imgUrl.startsWith('/')
+    ? `${imgUrl.split('?')[0]}?auto=webp&format=pjpg&optimize=medium&width=1200`
+    : imgUrl;
 }
 
 /**
@@ -104,6 +106,7 @@ async function getDefaultMetaImage(action) {
 async function extractMetaData(context, action) {
   const { request, content } = context;
   const { document } = content;
+  const { url } = request;
 
   // extract metadata
   const { meta = {} } = content;
@@ -147,8 +150,8 @@ async function extractMetaData(context, action) {
     meta.description = `${desc.slice(0, 25).join(' ')}${desc.length > 25 ? ' ...' : ''}`;
   }
   meta.url = getAbsoluteUrl(request.headers, request.url);
-  meta.image = optimizeMetaImage(meta.image || content.image || await getDefaultMetaImage(action));
-  meta.image = getAbsoluteUrl(request.headers, meta.image);
+  meta.image = getAbsoluteUrl(request.headers,
+    optimizeMetaImage(url, meta.image || content.image || await getDefaultMetaImage(action)));
 }
 
 module.exports = extractMetaData;

--- a/src/utils.js
+++ b/src/utils.js
@@ -43,7 +43,11 @@ function getAbsoluteUrl(headers, url) {
   if (typeof url !== 'string') {
     return null;
   }
-  return (url.startsWith('/') || url.startsWith('./'))
+  if (url.startsWith('./')) {
+    // eslint-disable-next-line no-param-reassign
+    url = url.substring(1);
+  }
+  return url.startsWith('/')
     ? `https://${getOriginalHost(headers)}${url}`
     : url;
 }

--- a/test/unit/html.pre.test.js
+++ b/test/unit/html.pre.test.js
@@ -20,7 +20,7 @@ const request = {
     host: 'foo.bar',
     'hlx-forwarded-host': 'www.foo.bar, foo-baz.hlx.page',
   },
-  url: '/baz.html',
+  url: '/foo/bar/baz.html',
 };
 const action = {
   request: {
@@ -230,6 +230,7 @@ describe('Testing pre.js', () => {
   });
 
   it('Meta image is extracted from image tag and optimized', () => {
+    const expectedUrl = `https://${request.headers['hlx-forwarded-host'].split(',')[0].trim()}${request.url.substring(0, request.url.lastIndexOf('/'))}/media_d6675ca179a0837756ceebe7f93aba2f14dabde.jpeg?auto=webp&format=pjpg&optimize=medium&width=1200`;
     const dom = new JSDOM(`
     <html>
       <body>
@@ -259,7 +260,7 @@ describe('Testing pre.js', () => {
     };
     pre(context, action);
 
-    assert.strictEqual(context.content.meta.image, `https://${request.headers['hlx-forwarded-host'].split(',')[0].trim()}/media_d6675ca179a0837756ceebe7f93aba2f14dabde.jpeg?auto=webp&format=pjpg&optimize=medium&width=1200`);
+    assert.strictEqual(context.content.meta.image, expectedUrl);
     assert.ok(!context.content.document.querySelector('.metadata'), 'Metadata block not removed');
   });
 
@@ -389,6 +390,7 @@ describe('Testing pre.js', () => {
   });
 
   it('Meta image uses and optimizes relative content.image as absolute URL', () => {
+    const expectedUrl = `https://${request.headers['hlx-forwarded-host'].split(',')[0].trim()}${request.url.substring(0, request.url.lastIndexOf('/'))}/media_d6675ca179a0837756ceebe7f93aba2f14dabde.jpeg?auto=webp&format=pjpg&optimize=medium&width=1200`;
     const dom = new JSDOM('<html></html>');
     const context = {
       content: {
@@ -400,7 +402,7 @@ describe('Testing pre.js', () => {
     };
     pre(context, action);
 
-    assert.strictEqual(context.content.meta.image, `https://${request.headers['hlx-forwarded-host'].split(',')[0].trim()}${context.content.image.substring(1)}?auto=webp&format=pjpg&optimize=medium&width=1200`);
+    assert.strictEqual(context.content.meta.image, expectedUrl);
   });
 
   it('Meta image uses JPG from repo if no content.image available', async () => {

--- a/test/unit/html.pre.test.js
+++ b/test/unit/html.pre.test.js
@@ -259,7 +259,7 @@ describe('Testing pre.js', () => {
     };
     pre(context, action);
 
-    assert.strictEqual(context.content.meta.image, `https://${request.headers['hlx-forwarded-host'].split(',')[0].trim()}./media_d6675ca179a0837756ceebe7f93aba2f14dabde.jpeg?auto=webp&format=pjpg&optimize=medium&width=1200`);
+    assert.strictEqual(context.content.meta.image, `https://${request.headers['hlx-forwarded-host'].split(',')[0].trim()}/media_d6675ca179a0837756ceebe7f93aba2f14dabde.jpeg?auto=webp&format=pjpg&optimize=medium&width=1200`);
     assert.ok(!context.content.document.querySelector('.metadata'), 'Metadata block not removed');
   });
 
@@ -400,7 +400,7 @@ describe('Testing pre.js', () => {
     };
     pre(context, action);
 
-    assert.strictEqual(context.content.meta.image, `https://${request.headers['hlx-forwarded-host'].split(',')[0].trim()}${context.content.image}?auto=webp&format=pjpg&optimize=medium&width=1200`);
+    assert.strictEqual(context.content.meta.image, `https://${request.headers['hlx-forwarded-host'].split(',')[0].trim()}${context.content.image.substring(1)}?auto=webp&format=pjpg&optimize=medium&width=1200`);
   });
 
   it('Meta image uses JPG from repo if no content.image available', async () => {


### PR DESCRIPTION
~~Removing `.` to in absolute path (works but ugly)~~
Resolve images starting with `./` relative to the path of the containing page.