### PR TITLE
Metadata block: support line-separated lists and arbitrary meta tags

### DIFF
--- a/src/html.htl
+++ b/src/html.htl
@@ -12,15 +12,19 @@
   <meta data-sly-test="${content.meta.image}" property="og:image" content="${content.meta.image}"/>
   <meta data-sly-test="${content.meta.image}" property="og:image:secure_url" content="${content.meta.image}"/>
   <meta data-sly-test="${content.meta.modifiedTime}" property="og:updated_time" content="${content.meta.modified_time}"/>
-  <sly data-sly-test="${content.meta.tags}" data-sly-list.tag="${content.meta.tags}">
-    <meta property="article:tag" content="${tag}"/>
-  </sly>
+<sly data-sly-test="${content.meta.tags}" data-sly-list.tag="${content.meta.tags}">
+  <meta property="article:tag" content="${tag}"/>
+</sly>
   <meta data-sly-test="${content.meta.section}" property="article:section" content="${section}"/>
   <meta data-sly-test="${content.meta.published_time}" property="article:published_time" content="${content.meta.published_time}"/>
   <meta data-sly-test="${content.meta.modified_time}" property="article:modified_time" content="${content.meta.modified_time}"/>
   <meta data-sly-test="${content.meta.title}" name="twitter:title" content="${content.meta.title}"/>
   <meta data-sly-test="${content.meta.description}" name="twitter:description" content="${content.meta.description}"/>
   <meta data-sly-test="${content.meta.image}" name="twitter:image" content="${content.meta.image}"/>
+<sly data-sly-test="${content.meta.custom}" data-sly-list="${content.meta.custom}">
+  <meta data-sly-test="${item.property}" property="${item.name}" content="${item.value}">
+  <meta data-sly-test="${!item.property}" name="${item.name}" content="${item.value}">
+</sly>
   <esi:include src="/head.html" onerror="continue"/>
 </head>
 <body data-sly-attribute="${content.document.body.attributesMap}">

--- a/test/unit/fixtures/page-metadata-block.html
+++ b/test/unit/fixtures/page-metadata-block.html
@@ -9,10 +9,12 @@
   <meta property="og:url" content="https://helix-pages.com/page-metadata-block.html">
   <meta property="og:image" content="https://helix-pages.com/default-meta-image.png?auto=webp&amp;format=pjpg&amp;optimize=medium&amp;width=1200">
   <meta property="og:image:secure_url" content="https://helix-pages.com/default-meta-image.png?auto=webp&amp;format=pjpg&amp;optimize=medium&amp;width=1200">
-  <meta property="article:tag" content="Foo">
-  <meta property="article:tag" content="Bar">
-  <meta property="article:tag" content="Baz">
+  <meta property="article:tag" content="One">
+  <meta property="article:tag" content="Two">
+  <meta property="article:tag" content="Three">
   <meta name="twitter:title" content="Meta title">
   <meta name="twitter:description" content="Meta description">
   <meta name="twitter:image" content="https://helix-pages.com/default-meta-image.png?auto=webp&amp;format=pjpg&amp;optimize=medium&amp;width=1200">
+  <meta name="template" content="default">
+  <meta property="article:publisher" content="https://www.facebook.com/Adobe">
 </head>

--- a/test/unit/fixtures/page-metadata-block.md
+++ b/test/unit/fixtures/page-metadata-block.md
@@ -7,3 +7,6 @@
 |Title|Meta title|
 |Description|Meta description|
 |Keywords|Foo, Bar, Baz|
+|Tags|One, Two, Three|
+|Template|default|
+|article:publisher|<https://www.facebook.com/Adobe>|


### PR DESCRIPTION
Fix #757
Fix #758
