### PR TITLE
chore: deprecate legacy sitemap documentation

### DIFF
--- a/docs/sitemap.md
+++ b/docs/sitemap.md
@@ -1,3 +1,5 @@
+<h2 style="color:red">DEPRECATED</h2>
+
 # How to add a Sitemap to your Helix Pages website
 
 A [`sitemap.xml`](https://en.wikipedia.org/wiki/Sitemaps) file helps search engines crawl and index your site, which increases the chances of visitors finding your content.

--- a/index.md
+++ b/index.md
@@ -69,8 +69,7 @@ function takeMeThere() {
 ## For developers
 
 - [Add an Atom feed to your site](docs/feed.md)
-- [Add a Sitemap to your site](docs/sitemap.md)
-- [Add an Index to your site](https://github.com/adobe/helix-home/blob/main/docs/setup-indexing.md)
+- [Add an Index to your site](https://main--helix-home--adobe.hlx.page/docs/setup-indexing.html)
 
 ## For authors
 


### PR DESCRIPTION
It no longer works with modern indices.