### PR TITLE
fix(ci): fix failing smoke tests init

### DIFF
--- a/release/deploy-ci.sh
+++ b/release/deploy-ci.sh
@@ -26,7 +26,7 @@ hedy -v --target=wsk,aws --deploy --entry-file=./cgi-bin/sitemap.js         --pk
 
 # update package secrets
 if [[ -f ".pages-package.env" ]]; then
-  hedy -v --no-build --no-hints --update-package --no-test --pkgVersion=ci$CIRCLE_BUILD_NUM
+  hedy -v --target=wsk,aws --no-build --no-hints --update-package --no-test --pkgVersion=ci$CIRCLE_BUILD_NUM
 fi
 
 # update helix-config.yaml


### PR DESCRIPTION
Smoke tests init is failing from time to time with error: 

```
--: updating package on Google ...
--: updating app (package) parameters ...
Using existing secret
error: Google - ENOENT: no such file or directory, open '********************************'
error: aborted due to errors during updatePackage
```
