### PR TITLE
fix(sidekick): temp revert incompatible changes (until 858)

### DIFF
--- a/tools/sidekick/app.js
+++ b/tools/sidekick/app.js
@@ -125,6 +125,7 @@
       ...cfg,
       innerHost,
       outerHost,
+      purgeHost: innerHost,
       host: publicHost,
       project: project || 'your Helix Pages project',
     };
@@ -768,7 +769,7 @@
         : [this.config.innerHost, this.config.outerHost, this.config.host];
       const u = new URL('https://adobeioruntime.net/api/v1/web/helix/helix-services/purge@v1');
       u.search = new URLSearchParams([
-        ['host', this.config.innerHost],
+        ['host', this.config.purgeHost],
         ['xfh', xfh.join(',')],
         ['path', pathname],
       ]).toString();

--- a/tools/sidekick/index.md
+++ b/tools/sidekick/index.md
@@ -96,7 +96,7 @@ Drag the Helix logo below to your browser's bookmark bar, or <a href="#" onclick
       '/* ** Helix Sidekick Bookmarklet ** */',
       '(() => {window.hlx=window.hlx||{};if(!window.hlx.sidekick){',
         `window.hlx.sidekickConfig=${JSON.stringify(config)};`,
-        'document.head.appendChild(document.createElement("script")).src="https://www.hlx.live/tools/sidekick/app.js";',
+        'document.head.appendChild(document.createElement("script")).src="https://www.hlx.page/tools/sidekick/app.js";',
       '}else{window.hlx.sidekick.toggle();}',
       '})();',
     ].join('');


### PR DESCRIPTION
- don't load sidekick from hlx.live yet, otherwise `innerHost` will be `*.hlx.live`
- keep `purgeHost` property in config 