### PR TITLE
fix(sidekick): share url missing byocdn flag

### DIFF
--- a/tools/sidekick/app.js
+++ b/tools/sidekick/app.js
@@ -290,6 +290,7 @@
     shareUrl.search = new URLSearchParams([
       ['project', config.project || ''],
       ['host', config.host || ''],
+      ['byocdn', !!config.byocdn],
       ['giturl', `https://github.com/${config.owner}/${config.repo}${config.ref ? `/tree/${config.ref}` : ''}`],
     ]).toString();
     return shareUrl.toString();


### PR DESCRIPTION
Fix #879 