### PR TITLE
feat(sidekick): suppress /index from webUrl in .lnk report

### DIFF
--- a/tools/sidekick/app.js
+++ b/tools/sidekick/app.js
@@ -401,6 +401,7 @@
             if (webUrl) {
               const u = new URL(webUrl);
               u.hostname = config[hostType];
+              u.pathname = u.pathname === '/index' ? '/' : u.pathname;
               url = u.toString();
             }
           }


### PR DESCRIPTION
Redirect to `/` instead of `/index`