### PR TITLE
fix: enable breaking june 2021 branch for testing

### DIFF
--- a/helix-config.yaml
+++ b/helix-config.yaml
@@ -58,6 +58,17 @@ strains:
     # universal runtime, using the helix-pages subdomain
     package: https://helix-pages.anywhere.run/pages_7_2_1
 
+  - name: breaking-202106
+    sticky: false
+    condition:
+      preflight.x-pages-version=: breaking-202106
+    code: https://github.com/adobe/helix-pages.git#breaking-202106
+    content: https://github.com/adobe/helix-pages.git#breaking-202106
+    static: https://github.com/adobe/helix-pages.git/htdocs#breaking-202106
+    package: https://helix-pages.anywhere.run/pages_6-1-0-breaking-202106
+    version-lock:
+      word2md: ci3440
+
   # temporary strain to test the metadata.json loading from sharepoint
   - name: breaking-800
     sticky: false

--- a/helix-config.yaml
+++ b/helix-config.yaml
@@ -65,7 +65,7 @@ strains:
     code: https://github.com/adobe/helix-pages.git#breaking-202106
     content: https://github.com/adobe/helix-pages.git#breaking-202106
     static: https://github.com/adobe/helix-pages.git/htdocs#breaking-202106
-    package: https://helix-pages.anywhere.run/pages_6-1-0-breaking-202106
+    package: https://helix-pages.anywhere.run/pages_7-2-1-breaking-202106
     version-lock:
       word2md: ci3440
 

--- a/helix-config.yaml
+++ b/helix-config.yaml
@@ -67,7 +67,7 @@ strains:
     static: https://github.com/adobe/helix-pages.git/htdocs#breaking-202106
     package: https://helix-pages.anywhere.run/pages_7-2-1-breaking-202106
     version-lock:
-      word2md: ci3440
+      word2md: ci3442
 
   # temporary strain to test the metadata.json loading from sharepoint
   - name: breaking-800


### PR DESCRIPTION
Not really a breaking change so far, but the changes in the table serialization should be thoroughly tested.

- [x] https://github.com/adobe/helix-word2md/issues/662