### PR TITLE
chore: restore all the diff tests and add a purge

### DIFF
--- a/test/pages/pages.test.js
+++ b/test/pages/pages.test.js
@@ -118,9 +118,9 @@ async function getMostVisited() {
 async function getTestSetup() {
   const mostVisitedUrls = await getMostVisited();
 
-  // mostVisitedUrls.push({
-  //   req_url: 'https://theblog--adobe.hlx.page/en/publish/2019/11/22/asia-pacific-insiders-share-their-inspiration-from-max-2019.html',
-  // });
+  mostVisitedUrls.push({
+    req_url: 'https://theblog--adobe.hlx.page/en/publish/2019/11/22/asia-pacific-insiders-share-their-inspiration-from-max-2019.html',
+  });
 
   // construct array of promises from fetch
   return processQueue(mostVisitedUrls, async (mostVisitedObj, _, results) => {
@@ -181,16 +181,10 @@ describe('document equivalence', function suite() {
           originalURL, originalContent, testURL, testContent,
         } = info;
 
-        // exclude image hashes that may vary
-        const noHashOriginalContent = originalContent.replace(/\/media_(.*?)\./gm, '/media_HASH.');
-
-        const orig_dom = new JSDOM(noHashOriginalContent).window.document;
+        const orig_dom = new JSDOM(originalContent).window.document;
         filterDOM(orig_dom);
 
-        // exclude image hashes that may vary
-        const noHashTestContent = testContent.replace(/\/media_(.*?)\./gm, '/media_HASH.');
-
-        const test_text = fixDomainInTestContent(noHashTestContent);
+        const test_text = fixDomainInTestContent(testContent);
         const test_dom = new JSDOM(test_text).window.document;
         filterDOM(test_dom);
 

--- a/test/pages/pages.test.js
+++ b/test/pages/pages.test.js
@@ -134,6 +134,9 @@ async function getTestSetup() {
     await fetch(originalURL, { method: 'PURGE' });
     await fetch(testURL, { method: 'PURGE' });
 
+    // "wait" 5s for the purge to be executed
+    await new Promise((resolve) => setTimeout(resolve, 5000));
+
     /* eslint-disable no-await-in-loop */
     let oRetries = 3;
     while (ret.originalStatus !== 200 && oRetries > 0) {

--- a/test/pages/pages.test.js
+++ b/test/pages/pages.test.js
@@ -130,6 +130,10 @@ async function getTestSetup() {
       testURL,
     };
 
+    // send PURGE requests to flush the cache
+    await fetch(originalURL, { method: 'PURGE' });
+    await fetch(testURL, { method: 'PURGE' });
+
     /* eslint-disable no-await-in-loop */
     let oRetries = 3;
     while (ret.originalStatus !== 200 && oRetries > 0) {


### PR DESCRIPTION
The purge helps getting the latest version of the html which seems to be cached from time to time. Still not 100% but re-playing the diff_test usually fix the issue after one or 2 retries.