### PR TITLE
chore(lint): ignore sidekick

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -5,6 +5,7 @@ test/integration
 test/integration-with-cgi-bin
 test/tmp/*
 test/loadtests/*
+tools/sidekick/*
 tmp/*
 coverage/*
 google/*


### PR DESCRIPTION
when running `npm run lint`