### PR TITLE
chore: exclude sidekick from linting

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -13,6 +13,7 @@
 module.exports = {
   root: true,
   extends: '@adobe/helix',
+  ignorePatterns: ['tools/sidekick/*.js'],
   rules: {
     // allow reassigning param
     'no-param-reassign': [2, { props: false }],


### PR DESCRIPTION
Do not `lint` sidekick, that's taken care of in https://github.com/adobe/helix-sidekick/